### PR TITLE
concept checker for atomic models and compile time tests

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -16,7 +16,7 @@ project cadmium
 ;
 
 build-project test ;
-#build-project test-compile ;
+build-project test-compile ;
 
 # Examples are not being built yet
 #build-project example ;

--- a/include/cadmium/concept/atomic_model_assert.hpp
+++ b/include/cadmium/concept/atomic_model_assert.hpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2013-2015, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ATOMIC_MODEL_ASSERT_HPP
+#define ATOMIC_MODEL_ASSERT_HPP
+
+//#include <pdevs_ports.hpp>
+//#include <message_bag.hpp>
+//#include <tuple>
+
+#include<cadmium/concept/concept_helper_functions.hpp>
+#include<cadmium/modeling/message_bag.hpp>
+
+namespace cadmium{
+    namespace concept {
+        template<template<typename> class MODEL> //check a template argument is required (for time)
+        constexpr void atomic_model_assert() {
+            //check portset types are defined
+            using ip=typename MODEL<float>::input_ports;
+            using op=typename MODEL<float>::output_ports;
+            using ip_bags=typename make_message_bags<ip>::type;
+            using op_bags=typename make_message_bags<op>::type;
+            //check port types are unique for in the portset tuples
+            static_assert(check_unique_elem_types<ip>::value(), "ambiguous port name in input ports");
+            static_assert(check_unique_elem_types<op>::value(), "ambiguous port name in output ports");
+            //check state is declared
+            static_assert(std::is_same<typename MODEL<float>::state_type,
+                                  decltype(MODEL<float>{}.state)>::value,
+                          "state is undefined or has the wrong type");
+
+            //check functions are declared
+            static_assert(std::is_same<decltype(std::declval<MODEL<float>>().output()),
+                                  op_bags>(),
+                          "Output function does not exist or does not return the right message bags");
+
+            static_assert(std::is_same<
+                                  decltype(std::declval<MODEL<float>>().confluence_transition(0.0, ip_bags{})),
+                                  void>(),
+                          "Confluence transition function undefined");
+
+            static_assert(std::is_same<
+                                  decltype(std::declval<MODEL<float>>().external_transition(0.0, ip_bags{})),
+                                  void>(),
+                          "External transition function undefined");
+
+            static_assert(std::is_same<
+                                  decltype(std::declval<MODEL<float>>().internal_transition()),
+                                  void>(),
+                          "Internal transition function undefined");
+
+            static_assert(std::is_same<decltype(std::declval<MODEL<float>>().time_advance()),
+                                  float>(),
+                          "Time advance function does not exist or does not return the right type of time");
+        }
+    }
+}
+#endif // ATOMIC_MODEL_ASSERT_HPP

--- a/include/cadmium/concept/concept_helper_functions.hpp
+++ b/include/cadmium/concept/concept_helper_functions.hpp
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2013-2015, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HELPER_FUNCTIONS_HPP
+#define HELPER_FUNCTIONS_HPP
+
+#include<tuple>
+
+namespace cadmium {
+    namespace concept {
+        namespace { //details
+            template<typename... Ts>
+            constexpr bool is_tuple(std::tuple<Ts...>) {
+                return true;
+            }
+
+            template<typename T, int S>
+            struct check_unique_elem_types_impl {
+                static constexpr bool value() {
+                    using elem=typename std::tuple_element<S - 1, T>::type;
+                    std::get<elem>(T{});
+                    return check_unique_elem_types_impl<T, S - 1>::value();
+                }
+            };
+
+            template<typename T>
+            struct check_unique_elem_types_impl<T, 0> {
+                static constexpr bool value() {
+                    return true;
+                }
+            };
+
+
+            template<typename T>
+            struct check_unique_elem_types {
+                static constexpr bool value() {
+                    return check_unique_elem_types_impl<T, std::tuple_size<T>::value>::value();
+                }
+            };
+
+        }
+    }
+}
+#endif // HELPER_FUNCTIONS_HPP
+

--- a/test-compile/Jamfile.jam
+++ b/test-compile/Jamfile.jam
@@ -1,0 +1,22 @@
+using testing ;
+
+#Tests that should compile
+compile valid_atomic_check_test.cpp ;
+compile generator_atomic_check_test.cpp ;
+compile passive_atomic_check_test.cpp ;
+compile valid_atomic_with_multiple_ports_check_test.cpp ;
+
+#Tests that should fail compilation
+compile-fail missing_input_ports_fails_compile_test.cpp ;
+compile-fail missing_output_ports_fails_compile_test.cpp ;
+compile-fail missing_internal_transition_fails_compile_test.cpp ;
+compile-fail missing_output_function_fails_compile_test.cpp ;
+compile-fail missing_confluence_transition_fails_compile_test.cpp ;
+compile-fail missing_external_transition_fails_compile_test.cpp ;
+compile-fail missing_time_advance_function_fails_compile_test.cpp ;
+compile-fail missing_state_type_fails_compile_test.cpp ;
+compile-fail missing_state_variable_fails_compile_test.cpp ;
+compile-fail repeated_input_ports_fail_compile_test.cpp ;
+compile-fail repeated_output_ports_fail_compile_test.cpp ;
+compile-fail inports_not_a_tuple_fail_compile.cpp ;
+compile-fail outports_not_a_tuple_fail_compile.cpp ;

--- a/test-compile/generator_atomic_check_test.cpp
+++ b/test-compile/generator_atomic_check_test.cpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that generator, when used as expected create valid atomic models not failing compilation on atomic_model_assert.
+ */
+
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<cadmium/basic_model/generator.hpp>
+
+//preparing the generator to be used as atomic model
+template<typename TIME>
+using floating_generator_base=cadmium::basic_models::generator<float, TIME>;
+
+template<typename TIME>
+struct floating_generator : public floating_generator_base<TIME> {
+    float period() const override {
+        return 1.0f;
+    }
+    float output_message() const override {
+        return 1.0f;
+    }
+};
+
+
+int main(){
+    cadmium::concept::atomic_model_assert<floating_generator>();
+}

--- a/test-compile/inports_not_a_tuple_fail_compile.cpp
+++ b/test-compile/inports_not_a_tuple_fail_compile.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+#include <vector>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_with_inputs_as_vector
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_with_inputs_as_vector() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::vector<in>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_with_inputs_as_vector>();
+}

--- a/test-compile/missing_confluence_transition_fails_compile_test.cpp
+++ b/test-compile/missing_confluence_transition_fails_compile_test.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_missing_confluence_function
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_missing_confluence_function() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_missing_confluence_function>();
+}

--- a/test-compile/missing_external_transition_fails_compile_test.cpp
+++ b/test-compile/missing_external_transition_fails_compile_test.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_missing_external_function
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_missing_external_function() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_missing_external_function>();
+}

--- a/test-compile/missing_input_ports_fails_compile_test.cpp
+++ b/test-compile/missing_input_ports_fails_compile_test.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests.
+ * In this case it is missing the declaration of input_ports type
+ * For external and confluence transition fuctions defined input as empty tuple of ports
+ */
+template<typename TIME>
+struct atomic_model_with_no_input_ports
+{
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_with_no_input_ports() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<std::tuple<>>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<std::tuple<>>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_with_no_input_ports>();
+}

--- a/test-compile/missing_internal_transition_fails_compile_test.cpp
+++ b/test-compile/missing_internal_transition_fails_compile_test.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_with_no_internal_transition
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_with_no_internal_transition() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out>;
+
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_with_no_internal_transition>();
+}

--- a/test-compile/missing_output_function_fails_compile_test.cpp
+++ b/test-compile/missing_output_function_fails_compile_test.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_missing_output_function
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_missing_output_function() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_missing_output_function>();
+}

--- a/test-compile/missing_output_ports_fails_compile_test.cpp
+++ b/test-compile/missing_output_ports_fails_compile_test.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests.
+ * In this case it is missing the declaration of input_ports type
+ * For external and confluence transition fuctions defined input as empty tuple of ports
+ */
+template<typename TIME>
+struct atomic_model_with_no_output_ports
+{
+    struct in : public cadmium::in_port<int>{};
+
+    constexpr atomic_model_with_no_output_ports() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<std::tuple<>>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_with_no_output_ports>();
+}

--- a/test-compile/missing_state_type_fails_compile_test.cpp
+++ b/test-compile/missing_state_type_fails_compile_test.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_missing_state_type_declaration
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_missing_state_type_declaration() noexcept {}
+
+    int state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_missing_state_type_declaration>();
+}

--- a/test-compile/missing_state_variable_fails_compile_test.cpp
+++ b/test-compile/missing_state_variable_fails_compile_test.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_missing_state_variable
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_missing_state_variable() noexcept {}
+    using state_type=int;
+
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_missing_state_variable>();
+}

--- a/test-compile/missing_time_advance_function_fails_compile_test.cpp
+++ b/test-compile/missing_time_advance_function_fails_compile_test.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_missing_time_advance_function
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_missing_time_advance_function() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_missing_time_advance_function>();
+}

--- a/test-compile/outports_not_a_tuple_fail_compile.cpp
+++ b/test-compile/outports_not_a_tuple_fail_compile.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+#include<vector>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_with_outputs_as_vector
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_with_outputs_as_vector() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::vector<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_with_outputs_as_vector>();
+}

--- a/test-compile/passive_atomic_check_test.cpp
+++ b/test-compile/passive_atomic_check_test.cpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that passive, when used as expected create valid atomic models not failing compilation on atomic_model_assert.
+ */
+
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<cadmium/basic_model/passive.hpp>
+
+//preparing the passive to be used as atomic model
+template<typename TIME>
+using floating_passive=cadmium::basic_models::passive<float, TIME>;
+
+int main(){
+    cadmium::concept::atomic_model_assert<floating_passive>();
+}

--- a/test-compile/repeated_input_ports_fail_compile_test.cpp
+++ b/test-compile/repeated_input_ports_fail_compile_test.cpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_with_repeated_input_ports
+{
+    struct in_one : public cadmium::in_port<int>{};
+    struct in_two : public cadmium::in_port<int>{};
+
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_with_repeated_input_ports() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in_one, in_two, in_one>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_with_repeated_input_ports>();
+}

--- a/test-compile/repeated_output_ports_fail_compile_test.cpp
+++ b/test-compile/repeated_output_ports_fail_compile_test.cpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct atomic_model_with_repeated_output_ports
+{
+    struct in : public cadmium::in_port<int>{};
+
+    struct out_one : public cadmium::out_port<int>{};
+    struct out_two : public cadmium::out_port<int>{};
+
+    constexpr atomic_model_with_repeated_output_ports() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out_one, out_two, out_one>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<atomic_model_with_repeated_output_ports>();
+}

--- a/test-compile/valid_atomic_check_test.cpp
+++ b/test-compile/valid_atomic_check_test.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct valid_atomic_model
+{
+    struct in : public cadmium::in_port<int>{};
+    struct out : public cadmium::out_port<int>{};
+
+    constexpr valid_atomic_model() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in>;
+    using output_ports=std::tuple<out>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<valid_atomic_model>();
+}

--- a/test-compile/valid_atomic_with_multiple_ports_check_test.cpp
+++ b/test-compile/valid_atomic_with_multiple_ports_check_test.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2013-2016, Damian Vicino
+ * Carleton University, Universite de Nice-Sophia Antipolis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test that a valid atomic model does not stop compilation on atomic_model_assert.
+ */
+
+#include<cadmium/modeling/ports.hpp>
+#include<cadmium/concept/atomic_model_assert.hpp>
+#include<tuple>
+#include<cadmium/modeling/message_bag.hpp>
+
+/**
+ * This model has no logic, only used for structural validation tests
+ */
+template<typename TIME>
+struct valid_atomic_with_multiple_ports
+{
+    struct in_one : public cadmium::in_port<int>{};
+    struct in_two : public cadmium::in_port<float>{};
+    struct in_three: public cadmium::in_port<int>{};
+    struct out_one : public cadmium::out_port<int[]>{};
+    struct out_two : public cadmium::out_port<float>{};
+    struct out_three : public cadmium::out_port<int[]>{};
+
+    constexpr valid_atomic_with_multiple_ports() noexcept {}
+    using state_type=int;
+    state_type state=0;
+    using input_ports=std::tuple<in_one, in_two, in_three>;
+    using output_ports=std::tuple<out_one, out_two, out_three>;
+
+    void internal_transition(){}
+    void external_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    void confluence_transition(TIME e, typename cadmium::make_message_bags<input_ports>::type mbs){}
+    typename cadmium::make_message_bags<output_ports>::type output() const{}
+    TIME time_advance() const{}
+};
+
+int main(){
+    cadmium::concept::atomic_model_assert<valid_atomic_with_multiple_ports>();
+}


### PR DESCRIPTION
Added a static_assert like atomic model validation. 
This will be used by the coupled models to validate models before coupling them.
Also, added compile time tests for validating invalid models fail compilation when validated.
