### PR TITLE
Error when compiling a model with make file. 

### DIFF
--- a/include/cadmium/modeling/message_bag.hpp
+++ b/include/cadmium/modeling/message_bag.hpp
@@ -28,6 +28,7 @@
 #define MESSAGE_BAG_HPP
 
 #include <vector>
+#include <tuple>
 
 namespace cadmium {
 template<typename T>


### PR DESCRIPTION
When I compiled an atomic model with makefile, I got this error:

In file included from main.cpp:1:0:
../../../../../cadmium/include/cadmium/modeling/message_bag.hpp: In function ‘cadmium::bag<typename cadmium::message_bag<PORT>::message_type>& cadmium::get_messages(T&)’:
../../../../../cadmium/include/cadmium/modeling/message_bag.hpp:61:12: error: ‘get’ is not a member of ‘std’
     return std::get<message_bag<PORT>>(mbs).messages;
            ^
../../../../../cadmium/include/cadmium/modeling/message_bag.hpp:61:37: error: expected primary-expression before ‘>’ token
     return std::get<message_bag<PORT>>(mbs).messages;
                                     ^

I solved it adding  "#include <tuple>" to message_bag.hpp
I think it is good idea to keep it to avoid this in the future with other compilers.
