### PR TITLE
Atomics port extraction

### DIFF
--- a/include/cadmium/basic_model/generator.hpp
+++ b/include/cadmium/basic_model/generator.hpp
@@ -48,18 +48,24 @@ namespace cadmium {
  * - advance(phase, t) = period - t
 */
 
-//This is a meta-model, it should be overloaded for declaring the tick time and tick values in the generator
-        template<typename TYPE, typename TIME> //TYPE is the type of Y
-        struct generator {
-            // port definition helpers can be defined here
-            struct out : public out_port<TYPE> {
+    //definitions used for defining the accumulator that need to be accessed by externals resources before instantiate the models
+    //This includes Ports referenced by couplings, and
+        template<typename VALUE>
+        struct generator_defs{
+            //custom ports
+            struct out : public out_port<VALUE> {
             };
+        };
 
-        private:
+
+    //This is a meta-model, it should be overloaded for declaring the tick time and tick values in the generator
+        template<typename VALUE, typename TIME> //VALUE is the type of Y
+        class generator {
+            using defs=generator_defs<VALUE>;// putting definitions in context
+        public:
             //these functions need to be overriden to define the generator behavior
             virtual TIME period() const =0; // time between consecutive messages
-            virtual TYPE output_message() const =0; // message to be output
-        public:
+            virtual VALUE output_message() const =0; // message to be output
             // required definitions start here
             // default constructor
             constexpr generator() noexcept {}
@@ -70,7 +76,7 @@ namespace cadmium {
 
             // ports definition
             using input_ports=std::tuple<>;
-            using output_ports=std::tuple<out>;
+            using output_ports=std::tuple<typename defs::out>;
 
             // internal transition
             void internal_transition() {}
@@ -88,7 +94,7 @@ namespace cadmium {
             // output function
             typename make_message_bags<output_ports>::type output() const {
                 typename make_message_bags<output_ports>::type bags;
-                cadmium::get_messages<out>(bags).push_back(output_message());
+                cadmium::get_messages<typename defs::out>(bags).push_back(output_message());
                 return bags;
             }
 

--- a/include/cadmium/basic_model/passive.hpp
+++ b/include/cadmium/basic_model/passive.hpp
@@ -50,12 +50,20 @@ namespace cadmium {
  * - time_advance(.) = infinite
 */
 
-        template<typename TYPE, typename TIME> //TYPE is the type of X
-        struct passive {
-            // port definition helper
-            struct in : public in_port<TYPE> {
+    //definitions used for defining the accumulator that need to be accessed by externals resources before instantiate the models
+    //This includes Ports referenced by couplings, and
+        template<typename VALUE>
+        struct passive_defs{
+            //custom ports
+            struct in : public in_port<VALUE> {
             };
+        };
 
+
+        template<typename VALUE, typename TIME> //VALUE is the type of X
+        class passive {
+            using defs=passive_defs<VALUE>;// putting definitions in context
+        public:
             // required definitions start here
             // default constructor
             constexpr passive() noexcept {}
@@ -65,7 +73,7 @@ namespace cadmium {
             state_type state = 0;
 
             // ports definition
-            using input_ports=std::tuple<in>;
+            using input_ports=std::tuple<typename defs::in>;
             using output_ports=std::tuple<>; //no output ports;
 
             // internal transition should never be run

--- a/test/pdevs_accumulator_model_test.cpp
+++ b/test/pdevs_accumulator_model_test.cpp
@@ -37,6 +37,7 @@ BOOST_AUTO_TEST_SUITE( pdevs_basic_models_suite )
     BOOST_AUTO_TEST_SUITE( pdevs_accumulator_suite )
 
         using floating_accumulator=cadmium::basic_models::accumulator<float, float>;
+        using floating_accumulator_defs=cadmium::basic_models::accumulator_defs<float>;
 
         BOOST_AUTO_TEST_CASE( it_is_constructable_test )
         {
@@ -76,7 +77,7 @@ BOOST_AUTO_TEST_SUITE( pdevs_basic_models_suite )
             BOOST_CHECK_EQUAL(0.0f, g.time_advance());
 
             typename cadmium::make_message_bags<floating_accumulator::input_ports>::type bags;
-            cadmium::get_messages<typename floating_accumulator::defs::add>(bags).push_back(5.0f);
+            cadmium::get_messages<floating_accumulator_defs::add>(bags).push_back(5.0f);
             BOOST_CHECK_THROW( g.external_transition(1.0f, bags), std::logic_error);
         }
 
@@ -95,23 +96,23 @@ BOOST_AUTO_TEST_SUITE( pdevs_basic_models_suite )
             g.state = std::make_tuple(10.0f, false); //accumulated one and not running a reset
             //introducing 3 new values, and setting
             typename cadmium::make_message_bags<floating_accumulator::input_ports>::type bags_one;
-            cadmium::get_messages<typename floating_accumulator::defs::add>(bags_one).push_back(5.0f);
+            cadmium::get_messages<typename floating_accumulator_defs::add>(bags_one).push_back(5.0f);
             g.external_transition(10.0f, bags_one);
             //validate state
             BOOST_CHECK_EQUAL(15.0f, std::get<float>(g.state));
             BOOST_CHECK_EQUAL(false, std::get<bool>(g.state));
 
             typename cadmium::make_message_bags<floating_accumulator::input_ports>::type bags_two;
-            cadmium::get_messages<typename floating_accumulator::defs::add>(bags_two).push_back(3.0f);
-            cadmium::get_messages<typename floating_accumulator::defs::add>(bags_two).push_back(7.0f);
+            cadmium::get_messages<typename floating_accumulator_defs::add>(bags_two).push_back(3.0f);
+            cadmium::get_messages<typename floating_accumulator_defs::add>(bags_two).push_back(7.0f);
             g.external_transition(9.0f, bags_two);
             //validate state
             BOOST_CHECK_EQUAL(25.0f, std::get<float>(g.state));
             BOOST_CHECK_EQUAL(false, std::get<bool>(g.state));
 
             typename cadmium::make_message_bags<floating_accumulator::input_ports>::type bags_three;
-            cadmium::get_messages<typename floating_accumulator::defs::add>(bags_three).push_back(3.0f);
-            cadmium::get_messages<typename floating_accumulator::defs::reset>(bags_three).emplace_back();
+            cadmium::get_messages<typename floating_accumulator_defs::add>(bags_three).push_back(3.0f);
+            cadmium::get_messages<typename floating_accumulator_defs::reset>(bags_three).emplace_back();
             g.external_transition(2.0f, bags_three);
             BOOST_CHECK_EQUAL(28.0f, std::get<float>(g.state));
             BOOST_CHECK_EQUAL(true, std::get<bool>(g.state));
@@ -119,15 +120,15 @@ BOOST_AUTO_TEST_SUITE( pdevs_basic_models_suite )
             //validate output
             auto outmb1 = g.output();
             typename cadmium::make_message_bags<floating_accumulator::output_ports>::type outmb_expected;
-            cadmium::get_messages<typename floating_accumulator::defs::sum>(outmb_expected).push_back(28.0f);
-            BOOST_CHECK_EQUAL(1, cadmium::get_messages<typename floating_accumulator::defs::sum>(outmb1).size());
-            BOOST_CHECK_EQUAL(cadmium::get_messages<typename floating_accumulator::defs::sum>(outmb_expected)[0],
-                              cadmium::get_messages<typename floating_accumulator::defs::sum>(outmb1)[0]);
+            cadmium::get_messages<typename floating_accumulator_defs::sum>(outmb_expected).push_back(28.0f);
+            BOOST_CHECK_EQUAL(1, cadmium::get_messages<typename floating_accumulator_defs::sum>(outmb1).size());
+            BOOST_CHECK_EQUAL(cadmium::get_messages<typename floating_accumulator_defs::sum>(outmb_expected)[0],
+                              cadmium::get_messages<typename floating_accumulator_defs::sum>(outmb1)[0]);
 
 
             //running confluence, because waiting for an internal here
             typename cadmium::make_message_bags<floating_accumulator::input_ports>::type bags_four;
-            cadmium::get_messages<typename floating_accumulator::defs::add>(bags_four).push_back(2.0f);
+            cadmium::get_messages<typename floating_accumulator_defs::add>(bags_four).push_back(2.0f);
             g.confluence_transition(0.0f, bags_four);
             BOOST_CHECK_EQUAL(2.0f, std::get<float>(g.state));
             BOOST_CHECK_EQUAL(false, std::get<bool>(g.state));

--- a/test/pdevs_generator_model_test.cpp
+++ b/test/pdevs_generator_model_test.cpp
@@ -38,6 +38,7 @@ BOOST_AUTO_TEST_SUITE( pdevs_basic_models_suite )
         const float init_period = 0.1f;
         const float init_output_message = 1.0f;
         using floating_generator_base=cadmium::basic_models::generator<float, float>;
+        using floating_generator_defs=cadmium::basic_models::generator_defs<float>;
         struct floating_generator : public floating_generator_base {
             float period() const override {
                 return init_period;
@@ -78,7 +79,7 @@ BOOST_AUTO_TEST_SUITE( pdevs_basic_models_suite )
         {
             auto g = floating_generator();
             auto o = g.output();
-            auto o_m =cadmium::get_messages<floating_generator::out>(o);
+            auto o_m =cadmium::get_messages<typename floating_generator_defs::out>(o);
             BOOST_CHECK_EQUAL( o_m.size(), 1);
             BOOST_CHECK_EQUAL( o_m.at(0), init_output_message);
         }

--- a/test/pdevs_passive_model_test.cpp
+++ b/test/pdevs_passive_model_test.cpp
@@ -36,6 +36,7 @@ BOOST_AUTO_TEST_SUITE( pdevs_basic_models_suite )
 BOOST_AUTO_TEST_SUITE( pdevs_passive_suite )
 
 using floating_passive=cadmium::basic_models::passive<float, float>;
+using floating_passive_defs=cadmium::basic_models::passive_defs<float>;
 
 BOOST_AUTO_TEST_CASE( it_is_constructable_test )
 {
@@ -52,7 +53,7 @@ BOOST_AUTO_TEST_CASE( it_throws_on_call_to_confluece_transition_test )
 {
     auto p = floating_passive();
     typename cadmium::make_message_bags<floating_passive::input_ports>::type bags;
-    cadmium::get_messages<floating_passive::in>(bags).push_back(1);
+    cadmium::get_messages<typename floating_passive_defs::in>(bags).push_back(1);
     BOOST_CHECK_THROW( p.confluence_transition(5.0, bags), std::logic_error);
 }
 
@@ -68,7 +69,7 @@ BOOST_AUTO_TEST_CASE( it_throws_on_call_to_output_function_test )
     bool is_inf_ta = std::isinf(p.time_advance());
     BOOST_CHECK_MESSAGE( is_inf_ta, "Passive model is not in passive state");
     typename cadmium::make_message_bags<floating_passive::input_ports>::type bags;
-    cadmium::get_messages<floating_passive::in>(bags).push_back(1);
+    cadmium::get_messages<typename floating_passive_defs::in>(bags).push_back(1);
     BOOST_CHECK_NO_THROW( p.external_transition(5.0, bags));
     is_inf_ta = std::isinf(p.time_advance());
     BOOST_CHECK_MESSAGE( is_inf_ta, "Passive model is not in passive state"  );

--- a/test/pdevs_simulator_test.cpp
+++ b/test/pdevs_simulator_test.cpp
@@ -34,6 +34,7 @@
 
 template<typename TIME>
 using int_accumulator=cadmium::basic_models::accumulator<int, TIME>;
+using int_accumulator_defs=cadmium::basic_models::accumulator_defs<int>;
 
 BOOST_AUTO_TEST_SUITE( pdevs_simulator_suite )
 
@@ -41,8 +42,7 @@ BOOST_AUTO_TEST_SUITE( pdevs_accumulator_suite )
 BOOST_AUTO_TEST_CASE( accumulator_model_simulation_test )
 {
     //construct a simulator for an accumulator
-    using simulator_t= cadmium::engine::simulator<int_accumulator, float>;
-    using model_t=simulator_t::model_type;
+    using simulator_t=cadmium::engine::simulator<int_accumulator, float>;
     simulator_t s{0.0f};
 
     BOOST_CHECK(s.next()==std::numeric_limits<float>::infinity());
@@ -52,23 +52,23 @@ BOOST_AUTO_TEST_CASE( accumulator_model_simulation_test )
     typename cadmium::make_message_bags<input_ports>::type input_bags;
     typename cadmium::make_message_bags<input_ports>::type empty_input;
     //insert values to add port and reset to empty
-    cadmium::get_messages<model_t::defs::add>(input_bags).assign(std::initializer_list<int>{1, 2, 3, 4});
-    cadmium::get_messages<model_t::defs::reset>(input_bags).clear();
+    cadmium::get_messages<int_accumulator_defs::add>(input_bags).assign(std::initializer_list<int>{1, 2, 3, 4});
+    cadmium::get_messages<int_accumulator_defs::reset>(input_bags).clear();
     
     //advance simulator
     s.advance_simulation(3.0f, input_bags);
     BOOST_CHECK(s.next() == std::numeric_limits<float>::infinity());
 
     //external input in reset triggers a reset
-    cadmium::get_messages<model_t::defs::add>(input_bags).clear();
-    cadmium::get_messages<model_t::defs::reset>(input_bags).emplace_back();
+    cadmium::get_messages<int_accumulator_defs::add>(input_bags).clear();
+    cadmium::get_messages<int_accumulator_defs::reset>(input_bags).emplace_back();
     s.advance_simulation(4.0f, input_bags); //here time is referring to absolute chronology, we are in simulation context.
     BOOST_CHECK(s.next() == 4.0f );
 
     //out provides the accumulated result
     auto o = s.collect_outputs(4.0f);
-    BOOST_REQUIRE(cadmium::get_messages<model_t::defs::sum>(o).size() == 1);
-    BOOST_CHECK(cadmium::get_messages<model_t::defs::sum>(o).at(0) == 10);
+    BOOST_REQUIRE(cadmium::get_messages<int_accumulator_defs::sum>(o).size() == 1);
+    BOOST_CHECK(cadmium::get_messages<int_accumulator_defs::sum>(o).at(0) == 10);
     s.advance_simulation(4.0f, empty_input);
     BOOST_CHECK(s.next() == std::numeric_limits<float>::infinity());
 
@@ -76,18 +76,18 @@ BOOST_AUTO_TEST_CASE( accumulator_model_simulation_test )
     s.advance_simulation(5.0f, input_bags);
     BOOST_CHECK(s.next() == 5.0f);
     o = s.collect_outputs(5.0f);
-    BOOST_REQUIRE(cadmium::get_messages<model_t::defs::sum>(o).size() == 1);
-    BOOST_CHECK(cadmium::get_messages<model_t::defs::sum>(o).at(0) == 0);
+    BOOST_REQUIRE(cadmium::get_messages<int_accumulator_defs::sum>(o).size() == 1);
+    BOOST_CHECK(cadmium::get_messages<int_accumulator_defs::sum>(o).at(0) == 0);
     s.advance_simulation(5.0f, empty_input);
     BOOST_CHECK(s.next() == std::numeric_limits<float>::infinity());
 
     //simultaneous external input in both ports increments and schedules reset
-    cadmium::get_messages<model_t::defs::add>(input_bags).assign(std::initializer_list<int>{1, 2, 3, 4});
+    cadmium::get_messages<int_accumulator_defs::add>(input_bags).assign(std::initializer_list<int>{1, 2, 3, 4});
     s.advance_simulation(6.0f, input_bags);
     BOOST_CHECK(s.next() == 6.0f);
     o = s.collect_outputs(6.0f);
-    BOOST_REQUIRE(cadmium::get_messages<model_t::defs::sum>(o).size() == 1);
-    BOOST_CHECK(cadmium::get_messages<model_t::defs::sum>(o).at(0) == 10);
+    BOOST_REQUIRE(cadmium::get_messages<int_accumulator_defs::sum>(o).size() == 1);
+    BOOST_CHECK(cadmium::get_messages<int_accumulator_defs::sum>(o).at(0) == 10);
     s.advance_simulation(6.0f, empty_input);
     BOOST_CHECK(s.next() == std::numeric_limits<float>::infinity());
 }
@@ -103,8 +103,8 @@ BOOST_AUTO_TEST_CASE( accumulator_simulation_throws_test ){
     typename cadmium::make_message_bags<model_t::input_ports>::type input_bags;
     typename cadmium::make_message_bags<model_t::input_ports>::type empty_input;
     //insert values to add port and reset to empty
-    cadmium::get_messages<model_t::defs::add>(input_bags).assign(std::initializer_list<int>{1, 2, 3, 4});
-    cadmium::get_messages<model_t::defs::reset>(input_bags).emplace_back();
+    cadmium::get_messages<int_accumulator_defs::add>(input_bags).assign(std::initializer_list<int>{1, 2, 3, 4});
+    cadmium::get_messages<int_accumulator_defs::reset>(input_bags).emplace_back();
 
     //try to obtain output when no internal transition is scheduled
     BOOST_CHECK_THROW(s.collect_outputs(6.0f), std::domain_error);


### PR DESCRIPTION
Extracted ports information out of basic models for being able to reference the types without speciallization from coupling mechanism
