### PR TITLE
test catching bug in get_engine_by_model when reading last model in tuple

### DIFF
--- a/include/cadmium/engine/pdevs_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_engine_helpers.hpp
@@ -130,7 +130,6 @@ namespace cadmium {
         struct get_engine_by_model_impl{
             using current_engine=typename std::tuple_element<S-1, CST>::type;
             using current_model=typename current_engine::model_type;
-            current_model c = TIMED_MODEL();
             using type=typename std::conditional<std::is_same<current_model, TIMED_MODEL>::value, current_engine, typename get_engine_by_model_impl<TIMED_MODEL, CST, S-1>::type>::type;
         };
 
@@ -163,7 +162,7 @@ namespace cadmium {
             using submodel_out_messages_type=boost::optional<typename make_message_bags<typename std::tuple<submodel_output_port>>::type>;
 
             static void fill(OUT_BAG& messages, CST& cst){
-                //precess one coupling
+                //process one coupling
                 auto& to_messages = get_messages<external_output_port>(messages);
                 if (submodel_out_messages_type from_messages_opt = get_engine_by_model<submodel_from, CST>(cst).outbox()){
                     auto& from_messages = get_messages<submodel_output_port>(*from_messages_opt);

--- a/test/pdevs_coordinator_test.cpp
+++ b/test/pdevs_coordinator_test.cpp
@@ -168,10 +168,10 @@ BOOST_AUTO_TEST_CASE( coordinated_generator_produces_right_output_test){
 using g2a_iports = std::tuple<>;
 struct g2a_coupled_out_port : public cadmium::out_port<int>{};
 using g2a_oports = std::tuple<g2a_coupled_out_port>;
-using g2a_submodels=cadmium::modeling::models_tuple<test_generator_to_reset, test_generator_to_add, test_accumulator>;
+using g2a_submodels=cadmium::modeling::models_tuple<test_accumulator, test_generator_to_reset, test_generator_to_add>;
 using g2a_eics=std::tuple<>;
 using g2a_eocs=std::tuple<
-//        cadmium::modeling::EOC<test_accumulator, test_accumulator_defs::sum, g2a_coupled_out_port>
+        cadmium::modeling::EOC<test_accumulator, test_accumulator_defs::sum, g2a_coupled_out_port>
 >;
 using g2a_ics=std::tuple<
 //        cadmium::modeling::IC<test_generator_to_add, add_one_generator_defs::out, test_accumulator, test_accumulator_defs::add>,

--- a/test/pdevs_engine_helper_test.cpp
+++ b/test/pdevs_engine_helper_test.cpp
@@ -85,19 +85,14 @@ using simulator_of_gen_a=cadmium::engine::simulator<floating_generator_a, float>
 using simulator_of_gen_b=cadmium::engine::simulator<floating_generator_b, float>;
 //Definition of a tuple with one simulator
 using tuple_sim_gens=std::tuple<simulator_of_gen_a, simulator_of_gen_b>;
-using found_engine_type=typename cadmium::engine::get_engine_type_by_model<floating_generator_a<float>, tuple_sim_gens>::type;
-BOOST_AUTO_TEST_CASE(get_engine_by_model_two_elements_test){
+BOOST_AUTO_TEST_CASE(get_engine_by_model_two_elements_get_first_test){
     tuple_sim_gens st;
-    std::get<simulator_of_gen_a>(st);
-    std::get<simulator_of_gen_b>(st);
-    static_assert(std::is_same<simulator_of_gen_a, std::tuple_element<0, tuple_sim_gens>::type>::value, "They are not equal");
+    auto eng_a=cadmium::engine::get_engine_by_model<floating_generator_a<float>, tuple_sim_gens>(st);
+}
 
-    found_engine_type f;
-    simulator_of_gen_a a;
-
-    static_assert(std::is_same<simulator_of_gen_a, found_engine_type>::value, "They are not equal");
-
-    auto eng=cadmium::engine::get_engine_by_model<floating_generator_a<float>, tuple_sim_gens>(st);
+BOOST_AUTO_TEST_CASE(get_engine_by_model_two_elements_get_last_test){
+    tuple_sim_gens st;
+    auto eng_b=cadmium::engine::get_engine_by_model<floating_generator_b<float>, tuple_sim_gens>(st);
 }
 
 


### PR DESCRIPTION
The test is catching a bug on the way the simulator of a model last in submodels tuple is required by the EOC