### PR TITLE
Engine was looking port information with wrong naming in EICs, fixed

### DIFF
--- a/include/cadmium/engine/pdevs_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_engine_helpers.hpp
@@ -351,9 +351,9 @@ namespace cadmium {
         template<typename TIME, typename INBAGS, typename CST, typename EICs, size_t S, typename LOGGER>
         struct route_external_input_coupled_messages_on_subcoordinators_impl{
             using current_EIC=typename std::tuple_element<S-1, EICs>::type;
-            using from_port=typename current_EIC::from_port;
-            using to_model=typename current_EIC::template to_model<TIME>;
-            using to_port=typename current_EIC::to_model_input_port;
+            using from_port=typename current_EIC::external_input_port;
+            using to_model=typename current_EIC::template submodel<TIME>;
+            using to_port=typename current_EIC::submodel_input_port;
 
             static void route(TIME t, const INBAGS& inbox, CST& engines){
                 auto to_engine=get_engine_by_model<to_model, CST>(engines);


### PR DESCRIPTION
At some point I changed naming convention of the couplings, I forgot to rename the EIC and no test cached it. 
I will add tests later, submitting fix to unblock the reporting user.
(Thanks cruizm@)