### PR TITLE
Bug fix output stale

### DIFF
--- a/include/cadmium/engine/pdevs_coordinator.hpp
+++ b/include/cadmium/engine/pdevs_coordinator.hpp
@@ -137,9 +137,6 @@ namespace cadmium {
                      return oss.str();
                 };
 
-                //cleanning the inbox and outbox for collecting new messages
-                _inbox = in_bags_type{};
-                _outbox = out_bags_type{};
                 //collecting if necessary
                 if (_next < t) {
                     throw std::domain_error("Trying to obtain output when not internal event is scheduled");
@@ -166,6 +163,9 @@ namespace cadmium {
              * @param t is the time the transition is expected to be run.
              */
             void advance_simulation(const TIME &t) {
+                //clean outbox because messages are routed before calling this funtion at a higher level
+                _outbox = out_bags_type{};
+                
                 auto log_info_advance = [](const TIME& from, const TIME& to) -> std::string {
                      std::ostringstream oss;
                      oss << "Coordinator for model ";

--- a/include/cadmium/engine/pdevs_simulator.hpp
+++ b/include/cadmium/engine/pdevs_simulator.hpp
@@ -161,6 +161,9 @@ namespace cadmium {
              * @param t is the time the transition is expected to be run.
             */
             void advance_simulation(TIME t) {
+                //clean outbox because messages are routed before calling this funtion at a higher level
+                _outbox = out_bags_type{};
+
                 auto log_info_advance = [](const TIME& from, const TIME& to) -> std::string {
                      std::ostringstream oss;
                      oss << "Simulator for model ";

--- a/test/boxes_cleanup_test.cpp
+++ b/test/boxes_cleanup_test.cpp
@@ -201,7 +201,6 @@ BOOST_AUTO_TEST_CASE( simple_outbox_cleanup_bug_test){
     std::string accum_states = "State for model cadmium::basic_models::accumulator";
     cadmium::engine::runner<float, DTOP, log_time_and_state> r{0.0};
     r.runUntil(5.0);
-    std::cout << oss.str();
     int count_initial_states = count_matches(expected_initial_state, oss.str());
     int count_expected_accumulation = count_matches(expected_accumulation_of_one, oss.str());
     int count_accum_states = count_matches(accum_states, oss.str());


### PR DESCRIPTION
Under certain conditions, some messages in the oubox of coordinators didn't get deleted after being processed. Then, they were routed again later. 
Added test for detecting the bug.
Added fix.