### PR TITLE
Adding support for lcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
       env:
       before_install:
           - brew upgrade boost cmake
+          - brew install lcov
 
   allow_failures:
           - os: linux


### PR DESCRIPTION
This is the first step to start creating test coverage reports for pushes.