### PR TITLE
Making cadmium run concurrently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,9 @@ endforeach(testCmpFailSrc)
 
 # Examples
 add_executable(clock_example example/main-clock.cpp)
+target_link_libraries(clock_example PUBLIC ${Boost_LIBRARIES})
 add_executable(count_fives_example example/main-count-fives.cpp)
+target_link_libraries(count_fives_example PUBLIC ${Boost_LIBRARIES})
 
 #Library Headers
 add_executable(cadmium_headers include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,7 @@ IF(CMAKE_BUILD_TYPE MATCHES Debug)
 ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
 
 set(Boost_USE_MULTITHREADED ON)
-find_package(Boost 1.67.0 COMPONENTS filesystem system thread unit_test_framework REQUIRED)
-find_package(Threads)
+find_package(Boost COMPONENTS unit_test_framework system thread REQUIRED)
 
 add_library(Cadmium INTERFACE)
 
@@ -40,8 +39,8 @@ FILE(GLOB TestSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/*_test.cpp)
 foreach(testSrc ${TestSources})
         get_filename_component(testName ${testSrc} NAME_WE)
         add_executable(${testName} test/main-test.cpp ${testSrc})
-        target_link_libraries(${testName} PUBLIC ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
-	add_test(${testName} ${testName})
+        target_link_libraries(${testName} PUBLIC ${Boost_LIBRARIES})
+	      add_test(${testName} ${testName})
 endforeach(testSrc)
 
 # Tests that should compile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,7 @@ endforeach(testCmpFailSrc)
 
 # Examples
 add_executable(clock_example example/main-clock.cpp)
-target_link_libraries(clock_example PUBLIC ${Boost_LIBRARIES})
 add_executable(count_fives_example example/main-count-fives.cpp)
-target_link_libraries(count_fives_example PUBLIC ${Boost_LIBRARIES})
 
 #Library Headers
 add_executable(cadmium_headers include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,42 +34,59 @@ else()
 endif()
 
 enable_testing()
-# Unit tests
-FILE(GLOB TestSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/*_test.cpp)
-foreach(testSrc ${TestSources})
-        get_filename_component(testName ${testSrc} NAME_WE)
-        add_executable(${testName} test/main-test.cpp ${testSrc})
-        target_link_libraries(${testName} PUBLIC ${Boost_LIBRARIES})
-	      add_test(${testName} ${testName})
-endforeach(testSrc)
 
-# Tests that should compile
-FILE(GLOB TestCompileSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test-compile/compiles/*_test.cpp)
-foreach(testCompSrc ${TestCompileSources})
-        get_filename_component(testCompName ${testCompSrc} NAME_WE)
-        add_executable(${testCompName} ${testCompSrc})
-        set_target_properties(${testCompName} PROPERTIES
-                              EXCLUDE_FROM_ALL TRUE
-                              EXCLUDE_FROM_DEFAULT_BUILD TRUE)
-        target_include_directories(${testCompName} PUBLIC test-compile/compiles)
-        add_test(NAME ${testCompName}
-                 COMMAND ${CMAKE_COMMAND} --build . --target ${testCompName}
-                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-endforeach(testCompSrc)
+#run all tests for sequential and concurrent versions
+set(EXEC_TYPES "seq" "par")
+foreach (exec_type ${EXEC_TYPES})
+    # Unit tests
+    FILE(GLOB TestSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/*_test.cpp)
+    foreach(testSrc ${TestSources})
+            get_filename_component(testName ${testSrc} NAME_WE)
+            set(testName "${testName}_${exec_type}")
+            add_executable(${testName} test/main-test.cpp ${testSrc})
+            if(exec_type STREQUAL "par")
+                target_compile_definitions(${testName} PUBLIC CADMIUM_EXECUTE_CONCURRENT)
+            endif()
+            target_link_libraries(${testName} PUBLIC ${Boost_LIBRARIES})
+    	      add_test(${testName} ${testName})
+    endforeach(testSrc)
 
-# Tests that should fail compilation
-FILE(GLOB TestCompileFailSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test-compile/compile-fails/*_test.cpp)
-foreach(testCmpFailSrc ${TestCompileFailSources})
-        get_filename_component(testCmpFailName ${testCmpFailSrc} NAME_WE)
-        add_executable(${testCmpFailName} ${testCmpFailSrc})
-        set_target_properties(${testCmpFailName} PROPERTIES
-                              EXCLUDE_FROM_ALL TRUE
-                              EXCLUDE_FROM_DEFAULT_BUILD TRUE)
-        add_test(NAME ${testCmpFailName}
-                 COMMAND ${CMAKE_COMMAND} --build . --target ${testCmpFailName}
-                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-        set_tests_properties(${testCmpFailName} PROPERTIES WILL_FAIL TRUE)
-endforeach(testCmpFailSrc)
+    # Tests that should compile
+    FILE(GLOB TestCompileSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test-compile/compiles/*_test.cpp)
+    foreach(testCompSrc ${TestCompileSources})
+            get_filename_component(testCompName ${testCompSrc} NAME_WE)
+            set(testCompName "${testCompName}_${exec_type}")
+            add_executable(${testCompName} ${testCompSrc})
+            set_target_properties(${testCompName} PROPERTIES
+                                  EXCLUDE_FROM_ALL TRUE
+                                  EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+            if(exec_type STREQUAL "par")
+                target_compile_definitions(${testCompName} PUBLIC CADMIUM_EXECUTE_CONCURRENT)
+            endif()
+            target_include_directories(${testCompName} PUBLIC test-compile/compiles)
+            add_test(NAME ${testCompName}
+                     COMMAND ${CMAKE_COMMAND} --build . --target ${testCompName}
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    endforeach(testCompSrc)
+
+    # Tests that should fail compilation
+    FILE(GLOB TestCompileFailSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test-compile/compile-fails/*_test.cpp)
+    foreach(testCmpFailSrc ${TestCompileFailSources})
+            get_filename_component(testCmpFailName ${testCmpFailSrc} NAME_WE)
+            set(testCmpFailName "${testCmpFailName}_${exec_type}")
+            add_executable(${testCmpFailName} ${testCmpFailSrc})
+            set_target_properties(${testCmpFailName} PROPERTIES
+                                  EXCLUDE_FROM_ALL TRUE
+                                  EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+            if(exec_type STREQUAL "par")
+                target_compile_definitions(${testCmpFailName} PUBLIC CADMIUM_EXECUTE_CONCURRENT)
+            endif()
+            add_test(NAME ${testCmpFailName}
+                     COMMAND ${CMAKE_COMMAND} --build . --target ${testCmpFailName}
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+            set_tests_properties(${testCmpFailName} PROPERTIES WILL_FAIL TRUE)
+    endforeach(testCmpFailSrc)
+endforeach(exec_type)
 
 # Examples
 add_executable(clock_example example/main-clock.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,9 @@ IF(CMAKE_BUILD_TYPE MATCHES Debug)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g -O0 -fprofile-arcs -ftest-coverage")
 ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
 
-set(Boost_USE_MULTITHREADED OFF)
-find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+set(Boost_USE_MULTITHREADED ON)
+find_package(Boost 1.67.0 COMPONENTS filesystem system thread unit_test_framework REQUIRED)
+find_package(Threads)
 
 add_library(Cadmium INTERFACE)
 
@@ -39,11 +40,11 @@ FILE(GLOB TestSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/*_test.cpp)
 foreach(testSrc ${TestSources})
         get_filename_component(testName ${testSrc} NAME_WE)
         add_executable(${testName} test/main-test.cpp ${testSrc})
-        target_link_libraries(${testName} PUBLIC ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+        target_link_libraries(${testName} PUBLIC ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 	add_test(${testName} ${testName})
 endforeach(testSrc)
 
-# Tests that should compile 
+# Tests that should compile
 FILE(GLOB TestCompileSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test-compile/compiles/*_test.cpp)
 foreach(testCompSrc ${TestCompileSources})
         get_filename_component(testCompName ${testCompSrc} NAME_WE)
@@ -81,6 +82,3 @@ set_target_properties(cadmium_headers PROPERTIES
                                                  EXCLUDE_FROM_ALL TRUE
                                                  EXCLUDE_FROM_DEFAULT_BUILD TRUE
                                                  LINKER_LANGUAGE CXX)
-
-
-

--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@ This project goal is replace CD++ with a more flexible and better performant imp
 
 ## Quick start
 ### Requirements
-* A C++14 compliant compiler. 
+* A C++14 compliant compiler.
 
 ### Install
 * The library is headers only. Then, it is enough to put the include directory in the path the compiler looks up for them.
+
+### Running cadmium in concurrent mode
+By default, cadmium runs single threaded. There is also a concurrent version behind a flag, but it requires Boost.Thread library and some changes need to be made when compiling:
+* The preprocessor variable CADMIUM_EXECUTE_CONCURRENT should be defined (add '-DCADMIUM_EXECUTE_CONCURRENT' when compiling ).
+* Boost.Thread and Boost.System libraries should be linked (add '-lboost_system -lboost_thread')
 
 ### Building tests and examples
 * Boost.Test, if running the testsfor running the tests.

--- a/include/cadmium/engine/concurrency_helpers.hpp
+++ b/include/cadmium/engine/concurrency_helpers.hpp
@@ -56,8 +56,12 @@ namespace cadmium {
               f(*first);
 
           }
-          auto wait_until_done = [](auto &t)->void { t.wait(); };
-          std::for_each(task_statuses.begin(), task_statuses.end(), wait_until_done);
+          auto thread_ready = [](auto& t){ return t.is_ready(); };
+          while(! std::all_of(task_statuses.begin(), task_statuses.end(), thread_ready) ){
+              threadpool.schedule_one_or_yield();
+          }
+          // auto wait_until_done = [](auto &t)->void { t.wait(); };
+          // std::for_each(task_statuses.begin(), task_statuses.end(), wait_until_done);
         }
 
 

--- a/include/cadmium/engine/concurrency_helpers.hpp
+++ b/include/cadmium/engine/concurrency_helpers.hpp
@@ -51,10 +51,10 @@ namespace cadmium {
           }
           auto thread_ready = [](auto& t){ return t.is_ready(); };
           while(! std::all_of(task_statuses.begin(), task_statuses.end(), thread_ready) ){
+              // if there are tasks in the threadpool queue, the main thread executes one
               threadpool.schedule_one_or_yield();
           }
-          // auto wait_until_done = [](auto &t)->void { t.wait(); };
-          // std::for_each(task_statuses.begin(), task_statuses.end(), wait_until_done);
+          //when concurrent_for_each end threadpool queue is empty
         }
 
 

--- a/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
@@ -215,7 +215,7 @@ namespace cadmium {
                         cadmium::dynamic::engine::collect_outputs_in_subcoordinators<TIME>(t, _subcoordinators, _threadpool);
 
                         // Use the EOC mapping to compose current level output
-                        _outbox = cadmium::dynamic::engine::collect_messages_by_eoc<TIME, LOGGER>(_external_output_couplings, _threadpool);
+                        _outbox = cadmium::dynamic::engine::collect_messages_by_eoc<TIME, LOGGER>(_external_output_couplings);
                     }
                 }
 
@@ -250,10 +250,10 @@ namespace cadmium {
 
                         //Route the messages standing in the outboxes to mapped inboxes following ICs and EICs
                         LOGGER::template log<cadmium::logger::logger_message_routing, cadmium::logger::coor_routing_ic_collect>(t, _model_id);
-                        cadmium::dynamic::engine::route_internal_coupled_messages_on_subcoordinators<TIME, LOGGER>(_internal_coupligns, _threadpool);
+                        cadmium::dynamic::engine::route_internal_coupled_messages_on_subcoordinators<TIME, LOGGER>(_internal_coupligns);
 
                         LOGGER::template log<cadmium::logger::logger_message_routing, cadmium::logger::coor_routing_eic_collect>(t, _model_id);
-                        cadmium::dynamic::engine::route_external_input_coupled_messages_on_subcoordinators<TIME, LOGGER>(_inbox, _external_input_couplings, _threadpool);
+                        cadmium::dynamic::engine::route_external_input_coupled_messages_on_subcoordinators<TIME, LOGGER>(_inbox, _external_input_couplings);
 
                         //recurse on advance_simulation
                         cadmium::dynamic::engine::advance_simulation_in_subengines<TIME>(t, _subcoordinators, _threadpool);

--- a/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
@@ -256,7 +256,7 @@ namespace cadmium {
                         cadmium::dynamic::engine::route_external_input_coupled_messages_on_subcoordinators<TIME, LOGGER>(_inbox, _external_input_couplings, _threadpool);
 
                         //recurse on advance_simulation
-                        cadmium::dynamic::engine::advance_simulation_in_subengines<TIME>(t, _subcoordinators, _threadpool);
+                        cadmium::dynamic::engine::advance_simulation_in_subengines<TIME>(t, _subcoordinators);
 
                         //set _last and _next
                         _last = t;

--- a/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
@@ -212,10 +212,10 @@ namespace cadmium {
                         LOGGER::template log<cadmium::logger::logger_message_routing, cadmium::logger::coor_routing_eoc_collect>(t, _model_id);
 
                         // Fill all outboxes and clean the inboxes in the lower levels recursively
-                        cadmium::dynamic::engine::collect_outputs_in_subcoordinators<TIME>(t, _subcoordinators);
+                        cadmium::dynamic::engine::collect_outputs_in_subcoordinators<TIME>(t, _subcoordinators, _threadpool);
 
                         // Use the EOC mapping to compose current level output
-                        _outbox = cadmium::dynamic::engine::collect_messages_by_eoc<TIME, LOGGER>(_external_output_couplings);
+                        _outbox = cadmium::dynamic::engine::collect_messages_by_eoc<TIME, LOGGER>(_external_output_couplings, _threadpool);
                     }
                 }
 
@@ -250,10 +250,10 @@ namespace cadmium {
 
                         //Route the messages standing in the outboxes to mapped inboxes following ICs and EICs
                         LOGGER::template log<cadmium::logger::logger_message_routing, cadmium::logger::coor_routing_ic_collect>(t, _model_id);
-                        cadmium::dynamic::engine::route_internal_coupled_messages_on_subcoordinators<TIME, LOGGER>(_internal_coupligns);
+                        cadmium::dynamic::engine::route_internal_coupled_messages_on_subcoordinators<TIME, LOGGER>(_internal_coupligns, _threadpool);
 
                         LOGGER::template log<cadmium::logger::logger_message_routing, cadmium::logger::coor_routing_eic_collect>(t, _model_id);
-                        cadmium::dynamic::engine::route_external_input_coupled_messages_on_subcoordinators<TIME, LOGGER>(_inbox, _external_input_couplings);
+                        cadmium::dynamic::engine::route_external_input_coupled_messages_on_subcoordinators<TIME, LOGGER>(_inbox, _external_input_couplings, _threadpool);
 
                         //recurse on advance_simulation
                         cadmium::dynamic::engine::advance_simulation_in_subengines<TIME>(t, _subcoordinators, _threadpool);

--- a/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
@@ -53,7 +53,9 @@ namespace cadmium {
                 external_couplings<TIME> _external_input_couplings;
                 internal_couplings<TIME> _internal_coupligns;
 
+                #ifdef CADMIUM_EXECUTE_CONCURRENT
                 boost::basic_thread_pool* _threadpool;
+                #endif //CADMIUM_EXECUTE_CONCURRENT
 
             public:
 
@@ -68,8 +70,11 @@ namespace cadmium {
                 coordinator() = delete;
 
                 coordinator(std::shared_ptr<model_type> coupled_model)
-                        : _model_id(coupled_model->get_id()), _threadpool(nullptr)
+                        : _model_id(coupled_model->get_id())
                 {
+                    #ifdef CADMIUM_EXECUTE_CONCURRENT
+                    _threadpool = nullptr;
+                    #endif //CADMIUM_EXECUTE_CONCURRENT
 
                     std::map<std::string, std::shared_ptr<engine<TIME>>> enginges_by_id;
 
@@ -173,15 +178,25 @@ namespace cadmium {
 
                     _last = initial_time;
                     //init all subcoordinators and find next transition time.
+
+                    #ifdef CADMIUM_EXECUTE_CONCURRENT
                     cadmium::dynamic::engine::init_subcoordinators<TIME>(initial_time, _subcoordinators, _threadpool);
+                    #else
+                    cadmium::dynamic::engine::init_subcoordinators<TIME>(initial_time, _subcoordinators);
+                    #endif //CADMIUM_EXECUTE_CONCURRENT
+
                     //find the one with the lowest next time
                     _next = cadmium::dynamic::engine::min_next_in_subcoordinators<TIME>(_subcoordinators);
                 }
+
+                #ifdef CADMIUM_EXECUTE_CONCURRENT
 
                 void init(TIME initial_time, boost::basic_thread_pool* threadpool) {
                     _threadpool = threadpool;
                     this->init(initial_time);
                 }
+
+                #endif //CADMIUM_EXECUTE_CONCURRENT
 
                 std::string get_model_id() const override {
                     return _model_id;
@@ -212,7 +227,11 @@ namespace cadmium {
                         LOGGER::template log<cadmium::logger::logger_message_routing, cadmium::logger::coor_routing_eoc_collect>(t, _model_id);
 
                         // Fill all outboxes and clean the inboxes in the lower levels recursively
+                        #ifdef CADMIUM_EXECUTE_CONCURRENT
                         cadmium::dynamic::engine::collect_outputs_in_subcoordinators<TIME>(t, _subcoordinators, _threadpool);
+                        #else
+                        cadmium::dynamic::engine::collect_outputs_in_subcoordinators<TIME>(t, _subcoordinators);
+                        #endif
 
                         // Use the EOC mapping to compose current level output
                         _outbox = cadmium::dynamic::engine::collect_messages_by_eoc<TIME, LOGGER>(_external_output_couplings);
@@ -256,7 +275,11 @@ namespace cadmium {
                         cadmium::dynamic::engine::route_external_input_coupled_messages_on_subcoordinators<TIME, LOGGER>(_inbox, _external_input_couplings);
 
                         //recurse on advance_simulation
+                        #ifdef CADMIUM_EXECUTE_CONCURRENT
                         cadmium::dynamic::engine::advance_simulation_in_subengines<TIME>(t, _subcoordinators, _threadpool);
+                        #else
+                        cadmium::dynamic::engine::advance_simulation_in_subengines<TIME>(t, _subcoordinators);
+                        #endif
 
                         //set _last and _next
                         _last = t;

--- a/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_coordinator.hpp
@@ -256,7 +256,7 @@ namespace cadmium {
                         cadmium::dynamic::engine::route_external_input_coupled_messages_on_subcoordinators<TIME, LOGGER>(_inbox, _external_input_couplings, _threadpool);
 
                         //recurse on advance_simulation
-                        cadmium::dynamic::engine::advance_simulation_in_subengines<TIME>(t, _subcoordinators);
+                        cadmium::dynamic::engine::advance_simulation_in_subengines<TIME>(t, _subcoordinators, _threadpool);
 
                         //set _last and _next
                         _last = t;

--- a/include/cadmium/engine/pdevs_dynamic_engine.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine.hpp
@@ -28,7 +28,10 @@
 #define CADMIUM_PDEVS_DYNAMIC_ENGINE_HPP
 
 #include <cadmium/modeling/dynamic_message_bag.hpp>
+
+#ifdef CADMIUM_EXECUTE_CONCURRENT
 #include <boost/thread/executors/basic_thread_pool.hpp>
+#endif
 
 namespace cadmium {
     namespace dynamic {
@@ -45,7 +48,9 @@ namespace cadmium {
             public:
                 virtual void init(TIME initial_time) = 0;
 
+                #ifdef CADMIUM_EXECUTE_CONCURRENT
                 virtual void init(TIME initial_time, boost::basic_thread_pool* threadpool) = 0;
+                #endif
 
                 virtual std::string get_model_id() const = 0;
 

--- a/include/cadmium/engine/pdevs_dynamic_engine.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine.hpp
@@ -28,6 +28,7 @@
 #define CADMIUM_PDEVS_DYNAMIC_ENGINE_HPP
 
 #include <cadmium/modeling/dynamic_message_bag.hpp>
+#include <boost/thread/executors/basic_thread_pool.hpp>
 
 namespace cadmium {
     namespace dynamic {
@@ -43,6 +44,8 @@ namespace cadmium {
             class engine {
             public:
                 virtual void init(TIME initial_time) = 0;
+
+                virtual void init(TIME initial_time, boost::basic_thread_pool* threadpool) = 0;
 
                 virtual std::string get_model_id() const = 0;
 

--- a/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
@@ -29,7 +29,7 @@
 
 #include <cadmium/modeling/dynamic_message_bag.hpp>
 #include <cadmium/engine/pdevs_dynamic_engine.hpp>
-#include <cadmium/engine/common_helpers.hpp>
+#include <cadmium/engine/concurrency_helpers.hpp>
 #include <cadmium/logger/common_loggers.hpp>
 
 #include <boost/any.hpp>
@@ -109,7 +109,7 @@ namespace cadmium {
                 if (threadpool == nullptr) {
                     std::for_each(subcoordinators.begin(), subcoordinators.end(), advance_time);
                 } else {
-                    cadmium::helper::concurrent_for_each(*threadpool, subcoordinators.begin(),
+                    cadmium::concurrency::concurrent_for_each(*threadpool, subcoordinators.begin(),
                                                          subcoordinators.end(), advance_time);
                 }
             }

--- a/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
@@ -32,10 +32,6 @@
 #include <cadmium/engine/concurrency_helpers.hpp>
 #include <cadmium/logger/common_loggers.hpp>
 
-#include <boost/any.hpp>
-#include <boost/bind.hpp>
-#include <boost/thread.hpp>
-
 #include <boost/thread/executors/basic_thread_pool.hpp>
 
 namespace cadmium {

--- a/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
@@ -32,11 +32,11 @@
 #include <cadmium/logger/common_loggers.hpp>
 
 #include <boost/any.hpp>
-#include <boost/thread.hpp>
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
+#include <boost/thread.hpp>
+#include <boost/thread/executors/basic_thread_pool.hpp>
 
-boost::asio::thread_pool threadpool(boost::thread::hardware_concurrency());
+boost::basic_thread_pool threadpool;
 
 namespace cadmium {
     namespace dynamic {
@@ -106,7 +106,7 @@ namespace cadmium {
             void advance_simulation_in_subengines(TIME t, subcoordinators_type<TIME>& subcoordinators) {
                 auto advance_time= [&t](auto &c)->void { c->advance_simulation(t); };
                 auto async_advance_time = [&advance_time, &threadpool, &t](auto & c)->void {
-                  boost::asio::post(threadpool, boost::bind<void>(advance_time, c));
+                  threadpool.submit(boost::bind<void>(advance_time, c));
                 };
 
                 std::for_each(subcoordinators.begin(), subcoordinators.end(), async_advance_time);

--- a/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
@@ -103,10 +103,15 @@ namespace cadmium {
             }
 
             template<typename TIME>
-            void advance_simulation_in_subengines(TIME t, subcoordinators_type<TIME>& subcoordinators) {
+            void advance_simulation_in_subengines(TIME t, subcoordinators_type<TIME>& subcoordinators, boost::basic_thread_pool* threadpool) {
                 auto advance_time= [&t](auto &c)->void { c->advance_simulation(t); };
 
-                std::for_each(subcoordinators.begin(), subcoordinators.end(), advance_time);
+                if (threadpool == nullptr) {
+                    std::for_each(subcoordinators.begin(), subcoordinators.end(), advance_time);
+                } else {
+                    cadmium::concurrency::concurrent_for_each(*threadpool, subcoordinators.begin(),
+                                                         subcoordinators.end(), advance_time);
+                }
             }
 
             template<typename TIME>

--- a/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
@@ -29,10 +29,12 @@
 
 #include <cadmium/modeling/dynamic_message_bag.hpp>
 #include <cadmium/engine/pdevs_dynamic_engine.hpp>
-#include <cadmium/engine/concurrency_helpers.hpp>
 #include <cadmium/logger/common_loggers.hpp>
 
+#ifdef CADMIUM_EXECUTE_CONCURRENT
+#include <cadmium/engine/concurrency_helpers.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
+#endif //CADMIUM_EXECUTE_CONCURRENT
 
 namespace cadmium {
     namespace dynamic {
@@ -92,12 +94,21 @@ namespace cadmium {
             template<typename TIME>
             using external_couplings = typename std::vector<external_coupling<TIME>>;
 
+            #ifdef CADMIUM_EXECUTE_CONCURRENT
             template<typename TIME>
             void init_subcoordinators(TIME t, subcoordinators_type<TIME>& subcoordinators, boost::basic_thread_pool* threadpool) {
                 auto init_coordinator = [&t, threadpool](auto & c)->void { c->init(t, threadpool); };
                 std::for_each(subcoordinators.begin(), subcoordinators.end(), init_coordinator);
             }
+            #else
+            template<typename TIME>
+            void init_subcoordinators(TIME t, subcoordinators_type<TIME>& subcoordinators) {
+                auto init_coordinator = [&t](auto & c)->void { c->init(t); };
+                std::for_each(subcoordinators.begin(), subcoordinators.end(), init_coordinator);
+            }
+            #endif //CADMIUM_EXECUTE_CONCURRENT
 
+            #ifdef CADMIUM_EXECUTE_CONCURRENT
             template<typename TIME>
             void advance_simulation_in_subengines(TIME t, subcoordinators_type<TIME>& subcoordinators, boost::basic_thread_pool* threadpool) {
                 auto advance_time= [&t](auto &c)->void { c->advance_simulation(t); };
@@ -109,7 +120,15 @@ namespace cadmium {
                                                          subcoordinators.end(), advance_time);
                 }
             }
+            #else
+            template<typename TIME>
+            void advance_simulation_in_subengines(TIME t, subcoordinators_type<TIME>& subcoordinators) {
+                auto advance_time= [&t](auto &c)->void { c->advance_simulation(t); };
+                std::for_each(subcoordinators.begin(), subcoordinators.end(), advance_time);
+            }
+            #endif //CADMIUM_EXECUTE_CONCURRENT
 
+            #ifdef CADMIUM_EXECUTE_CONCURRENT
             template<typename TIME>
             void collect_outputs_in_subcoordinators(TIME t, subcoordinators_type<TIME>& subcoordinators, boost::basic_thread_pool* threadpool) {
                 auto collect_output = [&t](auto & c)->void { c->collect_outputs(t); };
@@ -120,6 +139,13 @@ namespace cadmium {
                                                          subcoordinators.end(), collect_output);
                 }
             }
+            #else
+            template<typename TIME>
+            void collect_outputs_in_subcoordinators(TIME t, subcoordinators_type<TIME>& subcoordinators) {
+                auto collect_output = [&t](auto & c)->void { c->collect_outputs(t); };
+                std::for_each(subcoordinators.begin(), subcoordinators.end(), collect_output);
+            }
+            #endif //CADMIUM_EXECUTE_CONCURRENT
 
             template<typename TIME, typename LOGGER>
             cadmium::dynamic::message_bags collect_messages_by_eoc(const external_couplings<TIME>& coupling) {

--- a/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
@@ -126,7 +126,7 @@ namespace cadmium {
             }
 
             template<typename TIME, typename LOGGER>
-            cadmium::dynamic::message_bags collect_messages_by_eoc(const external_couplings<TIME>& coupling, boost::basic_thread_pool* threadpool) {
+            cadmium::dynamic::message_bags collect_messages_by_eoc(const external_couplings<TIME>& coupling) {
                 cadmium::dynamic::message_bags ret;
                 auto collect_output = [&ret](auto & c)->void {
                     cadmium::dynamic::message_bags outbox = c.first->outbox();
@@ -137,17 +137,12 @@ namespace cadmium {
                     }
                 };
 
-                if (threadpool == nullptr) {
-                    std::for_each(coupling.begin(), coupling.end(), collect_output);
-                } else {
-                    cadmium::concurrency::concurrent_for_each(*threadpool, coupling.begin(),
-                                                         coupling.end(), collect_output);
-                }
+                std::for_each(coupling.begin(), coupling.end(), collect_output);
                 return ret;
             }
 
             template<typename TIME, typename LOGGER>
-            void route_external_input_coupled_messages_on_subcoordinators(cadmium::dynamic::message_bags inbox, const external_couplings<TIME>& coupling, boost::basic_thread_pool* threadpool) {
+            void route_external_input_coupled_messages_on_subcoordinators(cadmium::dynamic::message_bags inbox, const external_couplings<TIME>& coupling) {
                 auto route_messages = [&inbox](auto & c)->void {
                     for (const auto& l : c.second) {
                         auto& to_inbox = c.first->inbox();
@@ -157,16 +152,11 @@ namespace cadmium {
                     }
                 };
 
-                if (threadpool == nullptr) {
-                    std::for_each(coupling.begin(), coupling.end(), route_messages);
-                } else {
-                    cadmium::concurrency::concurrent_for_each(*threadpool, coupling.begin(),
-                                                         coupling.end(), route_messages);
-                }
+                std::for_each(coupling.begin(), coupling.end(), route_messages);
             }
 
             template<typename TIME, typename LOGGER>
-            void route_internal_coupled_messages_on_subcoordinators(const internal_couplings<TIME>& coupling, boost::basic_thread_pool* threadpool) {
+            void route_internal_coupled_messages_on_subcoordinators(const internal_couplings<TIME>& coupling) {
                 auto route_messages = [](auto & c)->void {
                     for (const auto& l : c.second) {
                         auto& from_outbox = c.first.first->outbox();
@@ -176,12 +166,8 @@ namespace cadmium {
                         LOGGER::template log<cadmium::logger::logger_message_routing, cadmium::logger::coor_routing_collect>(message_to_log.from_port, message_to_log.to_port, message_to_log.from_messages, message_to_log.to_messages);
                     }
                 };
-                if (threadpool == nullptr) {
-                    std::for_each(coupling.begin(), coupling.end(), route_messages);
-                } else {
-                    cadmium::concurrency::concurrent_for_each(*threadpool, coupling.begin(),
-                                                         coupling.end(), route_messages);
-                }
+
+                std::for_each(coupling.begin(), coupling.end(), route_messages);
             }
 
             template<typename TIME>

--- a/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_engine_helpers.hpp
@@ -103,15 +103,10 @@ namespace cadmium {
             }
 
             template<typename TIME>
-            void advance_simulation_in_subengines(TIME t, subcoordinators_type<TIME>& subcoordinators, boost::basic_thread_pool* threadpool) {
+            void advance_simulation_in_subengines(TIME t, subcoordinators_type<TIME>& subcoordinators) {
                 auto advance_time= [&t](auto &c)->void { c->advance_simulation(t); };
 
-                if (threadpool == nullptr) {
-                    std::for_each(subcoordinators.begin(), subcoordinators.end(), advance_time);
-                } else {
-                    cadmium::concurrency::concurrent_for_each(*threadpool, subcoordinators.begin(),
-                                                         subcoordinators.end(), advance_time);
-                }
+                std::for_each(subcoordinators.begin(), subcoordinators.end(), advance_time);
             }
 
             template<typename TIME>

--- a/include/cadmium/engine/pdevs_dynamic_runner.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_runner.hpp
@@ -29,7 +29,9 @@
 
 #include <cadmium/engine/pdevs_dynamic_coordinator.hpp>
 
+#ifdef CADMIUM_EXECUTE_CONCURRENT
 #include <boost/thread/executors/basic_thread_pool.hpp>
+#endif //CADMIUM_EXECUTE_CONCURRENT
 
 namespace cadmium {
     namespace dynamic {
@@ -56,13 +58,17 @@ namespace cadmium {
 
                 cadmium::dynamic::engine::coordinator<TIME, LOGGER> _top_coordinator; //this only works for coupled models.
 
+                #ifdef CADMIUM_EXECUTE_CONCURRENT
                 boost::basic_thread_pool _threadpool;
+                #endif //CADMIUM_EXECUTE_CONCURRENT
+
             public:
                 //contructors
                 /**
                  * @brief set the dynamic parameters for the simulation
                  * @param init_time is the initial time of the simulation.
                  */
+                #ifdef CADMIUM_EXECUTE_CONCURRENT
                 explicit runner(std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> coupled_model, const TIME &init_time, unsigned const thread_count = boost::thread::hardware_concurrency())
                 : _top_coordinator(coupled_model),
                   _threadpool(thread_count){
@@ -72,6 +78,17 @@ namespace cadmium {
                     _next = _top_coordinator.next();
                 }
 
+                #else
+
+                explicit runner(std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> coupled_model, const TIME &init_time)
+                : _top_coordinator(coupled_model){
+                    LOGGER::template log<cadmium::logger::logger_global_time, cadmium::logger::run_global_time>(init_time);
+                    LOGGER::template log<cadmium::logger::logger_info, cadmium::logger::run_info>("Preparing model");
+                    _top_coordinator.init(init_time);
+                    _next = _top_coordinator.next();
+                }
+                #endif //CADMIUM_EXECUTE_CONCURRENT
+                
                 /**
                  * @brief runUntil starts the simulation and stops when the next event is scheduled after t.
                  * @param t is the limit time for the simulation.

--- a/include/cadmium/engine/pdevs_dynamic_runner.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_runner.hpp
@@ -29,7 +29,6 @@
 
 #include <cadmium/engine/pdevs_dynamic_coordinator.hpp>
 
-// #include <boost/thread.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 
 namespace cadmium {

--- a/include/cadmium/engine/pdevs_dynamic_runner.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_runner.hpp
@@ -29,6 +29,9 @@
 
 #include <cadmium/engine/pdevs_dynamic_coordinator.hpp>
 
+// #include <boost/thread.hpp>
+#include <boost/thread/executors/basic_thread_pool.hpp>
+
 namespace cadmium {
     namespace dynamic {
         namespace engine {
@@ -54,17 +57,19 @@ namespace cadmium {
 
                 cadmium::dynamic::engine::coordinator<TIME, LOGGER> _top_coordinator; //this only works for coupled models.
 
+                boost::basic_thread_pool _threadpool;
             public:
                 //contructors
                 /**
                  * @brief set the dynamic parameters for the simulation
                  * @param init_time is the initial time of the simulation.
                  */
-                explicit runner(std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> coupled_model, const TIME &init_time)
-                : _top_coordinator(coupled_model) {
+                explicit runner(std::shared_ptr<cadmium::dynamic::modeling::coupled<TIME>> coupled_model, const TIME &init_time, unsigned const thread_count = boost::thread::hardware_concurrency())
+                : _top_coordinator(coupled_model),
+                  _threadpool(thread_count){
                     LOGGER::template log<cadmium::logger::logger_global_time, cadmium::logger::run_global_time>(init_time);
                     LOGGER::template log<cadmium::logger::logger_info, cadmium::logger::run_info>("Preparing model");
-                    _top_coordinator.init(init_time);
+                    _top_coordinator.init(init_time, &_threadpool);
                     _next = _top_coordinator.next();
                 }
 

--- a/include/cadmium/engine/pdevs_dynamic_simulator.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_simulator.hpp
@@ -73,9 +73,11 @@ namespace cadmium {
                     LOGGER::template log<cadmium::logger::logger_state, cadmium::logger::sim_state>(initial_time, _model->get_id(), _model->model_state_as_string());
                 }
 
+                #ifdef CADMIUM_EXECUTE_CONCURRENT
                 void init(TIME initial_time, boost::basic_thread_pool* threadpool) {
                     this->init(initial_time);
                 }
+                #endif //CADMIUM_EXECUTE_CONCURRENT
 
                 std::string get_model_id() const override {
                     return _model->get_id();

--- a/include/cadmium/engine/pdevs_dynamic_simulator.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_simulator.hpp
@@ -73,6 +73,10 @@ namespace cadmium {
                     LOGGER::template log<cadmium::logger::logger_state, cadmium::logger::sim_state>(initial_time, _model->get_id(), _model->model_state_as_string());
                 }
 
+                void init(TIME initial_time, boost::basic_thread_pool* threadpool) {
+                    this->init(initial_time);
+                }
+
                 std::string get_model_id() const override {
                     return _model->get_id();
                 }


### PR DESCRIPTION
The publication [1] says that in the following pseudocode that represents the PDEVS Simulation Protocol, items 3. and 4. can be executed in parallel.

1.Until specified number of global transitions done,
2. Do global transition {
    3. For each imminent (own tN = global tN),
    compute output and send it to receivers
    4. For each active (imminent and input receiver},
    compute state transition (internal, external, confi.)
    5. Send own tN
    6. Advance global clock, global tN = min active tNs
}


In cadmium, the code that's executed on each global transition is:

1. _top_coordinator.collect_outputs(_next);
2._top_coordinator.advance_simulation(_next);
3. _next = _top_coordinator.next();

Internally collect_output does:
    collect_outputs_in_subcoordinators                                  // For each subcoordinator fill their outboxes (if simulator, calls output function first)
    _outbox = collect_messages_by_eoc(_external_output_couplings);      // With all child outputs full we can get outputs for current level

collect_outputs_in_subcoordinators can be run in parallel. We can assure messages are passed correctly because it always calls child's collect_output and waits until they all finish to collect the output for the next level (recursively, becuase collect_outputs_in_subcoordinators calls collect_output internally).

Internally advance_simulation does:
    route_internal_coupled_messages_on_subcoordinators(_internal_coupligns);     //Route the messages standing in the outboxes to mapped inboxes following ICs and EICs
    route_external_input_coupled_messages_on_subcoordinators(_inbox, _external_input_couplings);

    advance_simulation_in_subengines(t, _subcoordinators); // For each subcoordinator, makes the recursive call; if its a simulator it calls internal, external or confluence

    _last = t;
    _next = cadmium::dynamic::engine::min_next_in_subcoordinators<TIME>(_subcoordinators);

advance_simulation_in_subengines can be run in parallel. We can assure messages are passed correctly becuase it always routes the messages of the current level before advancing the simulation (and calling transition functions) in childs. The _next time is set correctly becuase it's calculated after all subengines finished advancing the simulation.


[1] [Using the Parallel DEVS Protocol for General Robust Simulation with Near Optimal Performance](https://github.com/SimulationEverywhere/cadmium/files/2979947/parallel.pdf), Bernard P. Zeigler
