### PR TITLE
Fixed bug that models were not checked recursivelly and fixed the tes…

### DIFF
--- a/include/cadmium/concept/atomic_model_assert.hpp
+++ b/include/cadmium/concept/atomic_model_assert.hpp
@@ -31,12 +31,12 @@
 #include<cadmium/modeling/message_bag.hpp>
 #include<cadmium/modeling/message_box.hpp>
 
-namespace cadmium {
-    namespace concept {
+namespace cadmium::concept {
+    namespace pdevs {
         //PDEVS
         template<typename FLOATING_MODEL>
         //check a template argument is required (for time)
-        constexpr void pdevs_atomic_model_float_time_assert() {
+        constexpr void atomic_model_float_time_assert() {
             //check portset types are defined
             using ip=typename FLOATING_MODEL::input_ports;
             using op=typename FLOATING_MODEL::output_ports;
@@ -77,16 +77,18 @@ namespace cadmium {
 
         template<template<typename> class MODEL>
         //check a template argument is required (for time)
-        constexpr void pdevs_atomic_model_assert() {
+        constexpr void atomic_model_assert() {
             //setting float as time to use by model
             using floating_model=MODEL<float>;
-            pdevs_atomic_model_float_time_assert<floating_model>();
+            atomic_model_float_time_assert<floating_model>();
         }
+    }
 
-        //DEVS
+    //DEVS
+    namespace devs {
         template<typename FLOATING_MODEL>
         //check a template argument is required (for time)
-        constexpr void devs_atomic_model_float_time_assert() {
+        constexpr void atomic_model_float_time_assert() {
             //check portset types are defined
             using ip=typename FLOATING_MODEL::input_ports;
             using op=typename FLOATING_MODEL::output_ports;
@@ -122,12 +124,12 @@ namespace cadmium {
 
         template<template<typename> class MODEL>
         //check a template argument is required (for time)
-        constexpr void devs_atomic_model_assert() {
+        constexpr void atomic_model_assert() {
             //setting float as time to use by model
             using floating_model=MODEL<float>;
-            devs_atomic_model_float_time_assert<floating_model>();
+            atomic_model_float_time_assert<floating_model>();
         }
-
     }
 }
+
 #endif // CADMIUM_ATOMIC_MODEL_ASSERT_HPP

--- a/include/cadmium/concept/coupled_model_assert.hpp
+++ b/include/cadmium/concept/coupled_model_assert.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013-2016, Damian Vicino
+ * Copyright (c) 2013-2019, Damian Vicino
  * Carleton University, Universite de Nice-Sophia Antipolis
  * All rights reserved.
  *
@@ -33,143 +33,142 @@
 #include<cadmium/modeling/ports.hpp>
 #include<type_traits>
 
-namespace cadmium {
-    namespace concept {
+namespace cadmium::concept {
+    //static assert over the EIC descriptions
+    template<typename IN, typename EICs, int S>
+    struct assert_each_eic {
+        static constexpr bool value() {
+            using EP=typename std::tuple_element<S - 1, EICs>::type::external_input_port;
+            using SUBMODEL=typename std::tuple_element<S -
+                                                       1, EICs>::type::template submodel<float>; //using float time, ports should not depend on time
+            using IP=typename std::tuple_element<S - 1, EICs>::type::submodel_input_port;
+            //ports are input ports
+            static_assert(EP::kind == port_kind::in, "The external port in a EIC is not an input port");
+            static_assert(IP::kind == port_kind::in, "The internal port in a EIC is not an input port");
+            //check internal port is defined in submodel
+            static_assert(has_port_in_tuple<IP, typename SUBMODEL::input_ports>::value(),
+                          "External port in EIC is not defined as external port in the model");
+            //check external port is defined in the model
+            static_assert(has_port_in_tuple<EP, IN>::value(),
+                          "External port in EIC is not defined as external port in the model");
+            //check the internal port matches message type with the external port
+            static_assert(std::is_same<typename EP::message_type, typename IP::message_type>(),
+                          "The message type does not match in EIC description");
+
+            //recursive step
+            return assert_each_eic<IN, EICs, S - 1>::value();
+        }
+    };
+
+    template<typename IN, typename EICs>
+    struct assert_each_eic<IN, EICs, 0> {
+        static constexpr bool value() {
+            return true;
+        }
+    };
+
+
+    template<typename IN, typename EICs>
+    constexpr void assert_eic(IN p_in, EICs eics) {
+        assert_each_eic<IN, EICs, std::tuple_size<EICs>::value>::value();//check couple individually
+        static_assert(is_tuple<EICs>(), "EIC is not a tuple");
+    }
+
+    //static assert over the EOC descriptions
+    template<typename OUT, typename EOCs, int S>
+    struct assert_each_eoc {
+        static constexpr bool value() {
+            using EP=typename std::tuple_element<S - 1, EOCs>::type::external_output_port;
+            using SUBMODEL=typename std::tuple_element<S -
+                                                       1, EOCs>::type::template submodel<float>; //using float time, ports should not depend on time
+            using IP=typename std::tuple_element<S - 1, EOCs>::type::submodel_output_port;
+            //ports are output ports
+            static_assert(EP::kind == port_kind::out, "The external port in a EOC is not an output port");
+            static_assert(IP::kind == port_kind::out, "The internal port in a EOC is not an output port");
+            //check internal port is defined in submodel
+            static_assert(has_port_in_tuple<IP, typename SUBMODEL::output_ports>::value(),
+                          "Internal port in EOC is not defined as external port in the submodel");
+            //check external port is defined in the model
+            static_assert(has_port_in_tuple<EP, OUT>::value(),
+                          "External port in EIC is not defined as external port in the model");
+            //check the internal port matches message type with the external port
+            static_assert(std::is_same<typename EP::message_type, typename IP::message_type>(),
+                          "The message type does not match in EOC description");
+
+            //recursive step
+            return assert_each_eoc<OUT, EOCs, S - 1>::value();
+        }
+    };
+
+    template<typename OUT, typename EOCs>
+    struct assert_each_eoc<OUT, EOCs, 0> {
+        static constexpr bool value() {
+            return true;
+        }
+    };
+
+
+    template<typename OUT, typename EOCs>
+    constexpr void assert_eoc(OUT p_out, EOCs eocs) {
+        assert_each_eoc<OUT, EOCs, std::tuple_size<EOCs>::value>::value();//check couple individually
+        static_assert(is_tuple<EOCs>(), "EOC is not a tuple");
+    }
+
+    //static assert over the IC descriptions
+    template<typename ICs, int S>
+    struct assert_each_ic {
+        static constexpr bool value() {
+            using FROM_MODEL=typename std::tuple_element<S -
+                                                         1, ICs>::type::template from_model<float>;//using float time, ports should not depend on time
+            using FROM_PORT=typename std::tuple_element<S - 1, ICs>::type::from_model_output_port;
+            using TO_MODEL=typename std::tuple_element<
+                    S - 1, ICs>::type::template to_model<float>; //using float time, ports should not depend on time
+            using TO_PORT=typename std::tuple_element<S - 1, ICs>::type::to_model_input_port;
+
+            //ports are proper kind
+            static_assert(FROM_PORT::kind == port_kind::out,
+                          "The port in from_model in a IC is not an output port");
+            static_assert(TO_PORT::kind == port_kind::in, "The port in a to_model in a IC is not an input port");
+
+            //check ports are defined in submodels
+            static_assert(has_port_in_tuple<FROM_PORT, typename FROM_MODEL::output_ports>::value(),
+                          "Output port used in IC is not defined in the submodel");
+            static_assert(has_port_in_tuple<TO_PORT, typename TO_MODEL::input_ports>::value(),
+                          "Input port in IC is not defined in the submodel");
+            //check the internal port matches message type with the external port
+            static_assert(std::is_same<typename TO_PORT::message_type, typename FROM_PORT::message_type>(),
+                          "The message type does not match in IC description");
+
+            //not loop in IC
+            static_assert(!std::is_same<FROM_MODEL, TO_MODEL>(), "The IC detected a coupling-to-self loop");
+
+            //recursive step
+            return assert_each_ic<ICs, S - 1>::value();
+        }
+    };
+
+    template<typename ICs>
+    struct assert_each_ic<ICs, 0> {
+        static constexpr bool value() {
+            return true;
+        }
+    };
+
+
+    template<typename ICs>
+    constexpr void assert_ic(ICs ics) {
+        assert_each_ic<ICs, std::tuple_size<ICs>::value>::value();//check couple individually
+        static_assert(is_tuple<ICs>(), "ICs is not a tuple");
+    }
+
+    namespace pdevs {
         //forward declaration
         template<typename MODEL>
         constexpr void coupled_model_float_time_assert();
 
-        //static assert over the EIC descriptions
-        template<typename IN, typename EICs, int S>
-        struct assert_each_eic {
-            static constexpr bool value() {
-                using EP=typename std::tuple_element<S - 1, EICs>::type::external_input_port;
-                using SUBMODEL=typename std::tuple_element<S -
-                                                           1, EICs>::type::template submodel<float>; //using float time, ports should not depend on time
-                using IP=typename std::tuple_element<S - 1, EICs>::type::submodel_input_port;
-                //ports are input ports
-                static_assert(EP::kind == port_kind::in, "The external port in a EIC is not an input port");
-                static_assert(IP::kind == port_kind::in, "The internal port in a EIC is not an input port");
-                //check internal port is defined in submodel
-                static_assert(has_port_in_tuple<IP, typename SUBMODEL::input_ports>::value(),
-                              "External port in EIC is not defined as external port in the model");
-                //check external port is defined in the model
-                static_assert(has_port_in_tuple<EP, IN>::value(),
-                              "External port in EIC is not defined as external port in the model");
-                //check the internal port matches message type with the external port
-                static_assert(std::is_same<typename EP::message_type, typename IP::message_type>(),
-                              "The message type does not match in EIC description");
-
-                //recursive step
-                return assert_each_eic<IN, EICs, S - 1>::value();
-            }
-        };
-
-        template<typename IN, typename EICs>
-        struct assert_each_eic<IN, EICs, 0> {
-            static constexpr bool value() {
-                return true;
-            }
-        };
-
-
-        template<typename IN, typename EICs>
-        constexpr void assert_eic(IN p_in, EICs eics) {
-            assert_each_eic<IN, EICs, std::tuple_size<EICs>::value>::value();//check couple individually
-            static_assert(is_tuple<EICs>(), "EIC is not a tuple");
-        }
-
-        //static assert over the EOC descriptions
-        template<typename OUT, typename EOCs, int S>
-        struct assert_each_eoc {
-            static constexpr bool value() {
-                using EP=typename std::tuple_element<S - 1, EOCs>::type::external_output_port;
-                using SUBMODEL=typename std::tuple_element<S -
-                                                           1, EOCs>::type::template submodel<float>; //using float time, ports should not depend on time
-                using IP=typename std::tuple_element<S - 1, EOCs>::type::submodel_output_port;
-                //ports are output ports
-                static_assert(EP::kind == port_kind::out, "The external port in a EOC is not an output port");
-                static_assert(IP::kind == port_kind::out, "The internal port in a EOC is not an output port");
-                //check internal port is defined in submodel
-                static_assert(has_port_in_tuple<IP, typename SUBMODEL::output_ports>::value(),
-                              "Internal port in EOC is not defined as external port in the submodel");
-                //check external port is defined in the model
-                static_assert(has_port_in_tuple<EP, OUT>::value(),
-                              "External port in EIC is not defined as external port in the model");
-                //check the internal port matches message type with the external port
-                static_assert(std::is_same<typename EP::message_type, typename IP::message_type>(),
-                              "The message type does not match in EOC description");
-
-                //recursive step
-                return assert_each_eoc<OUT, EOCs, S - 1>::value();
-            }
-        };
-
-        template<typename OUT, typename EOCs>
-        struct assert_each_eoc<OUT, EOCs, 0> {
-            static constexpr bool value() {
-                return true;
-            }
-        };
-
-
-        template<typename OUT, typename EOCs>
-        constexpr void assert_eoc(OUT p_out, EOCs eocs) {
-            assert_each_eoc<OUT, EOCs, std::tuple_size<EOCs>::value>::value();//check couple individually
-            static_assert(is_tuple<EOCs>(), "EOC is not a tuple");
-        }
-
-        //static assert over the IC descriptions
-        template<typename ICs, int S>
-        struct assert_each_ic {
-            static constexpr bool value() {
-                using FROM_MODEL=typename std::tuple_element<S -
-                                                             1, ICs>::type::template from_model<float>;//using float time, ports should not depend on time
-                using FROM_PORT=typename std::tuple_element<S - 1, ICs>::type::from_model_output_port;
-                using TO_MODEL=typename std::tuple_element<
-                        S - 1, ICs>::type::template to_model<float>; //using float time, ports should not depend on time
-                using TO_PORT=typename std::tuple_element<S - 1, ICs>::type::to_model_input_port;
-
-                //ports are proper kind
-                static_assert(FROM_PORT::kind == port_kind::out,
-                              "The port in from_model in a IC is not an output port");
-                static_assert(TO_PORT::kind == port_kind::in, "The port in a to_model in a IC is not an input port");
-
-                //check ports are defined in submodels
-                static_assert(has_port_in_tuple<FROM_PORT, typename FROM_MODEL::output_ports>::value(),
-                              "Output port used in IC is not defined in the submodel");
-                static_assert(has_port_in_tuple<TO_PORT, typename TO_MODEL::input_ports>::value(),
-                              "Input port in IC is not defined in the submodel");
-                //check the internal port matches message type with the external port
-                static_assert(std::is_same<typename TO_PORT::message_type, typename FROM_PORT::message_type>(),
-                              "The message type does not match in IC description");
-
-                //not loop in IC
-                static_assert(!std::is_same<FROM_MODEL, TO_MODEL>(), "The IC detected a coupling-to-self loop");
-
-                //recursive step
-                return assert_each_ic<ICs, S - 1>::value();
-            }
-        };
-
-        template<typename ICs>
-        struct assert_each_ic<ICs, 0> {
-            static constexpr bool value() {
-                return true;
-            }
-        };
-
-
-        template<typename ICs>
-        constexpr void assert_ic(ICs ics) {
-            assert_each_ic<ICs, std::tuple_size<ICs>::value>::value();//check couple individually
-            static_assert(is_tuple<ICs>(), "ICs is not a tuple");
-        }
-
-
         //asserting the submodels are proper coupled or atomic modes.
         template<typename MODELs, int S>
-        struct assert_each_model {
+        struct assert_each_submodel {
             using MODEL=typename std::tuple_element<S - 1, MODELs>::type;
             //testing if model has to be checked as atomic or coupled
             using atomic_detected=char;
@@ -181,30 +180,26 @@ namespace cadmium {
             template<typename M>
             static coupled_detected test(...);
 
-            static constexpr bool value() {
-                if (sizeof(test<MODEL>) == sizeof(atomic_detected)) {
-                    pdevs_atomic_model_float_time_assert<MODEL>();
+            static constexpr void check() {
+                if constexpr (sizeof(test<MODEL>(0)) == sizeof(atomic_detected)) {
+                    cadmium::concept::pdevs::atomic_model_float_time_assert<MODEL>();
                 } else {
                     coupled_model_float_time_assert<MODEL>();
                 }
-                return assert_each_model<MODELs, S - 1>();
+                assert_each_submodel<MODELs, S - 1>();
             }
         };
 
         template<typename MODELs>
-        struct assert_each_model<MODELs, 0> {
-            static constexpr bool value() {
-                return true;//TODO
-            }
+        struct assert_each_submodel<MODELs, 0> {
+            static constexpr void check() {}
         };
 
-
         template<typename MODELs>
-        constexpr void assert_submodels(MODELs models) {
-            assert_each_model<MODELs, std::tuple_size<MODELs>::value>::value();//check couple individually
-            static_assert(is_tuple(models), "Submodels is not a tuple");
+        constexpr void assert_submodels() {
+            static_assert(is_tuple<MODELs>(), "Submodels is not a tuple");
+            assert_each_submodel<MODELs, std::tuple_size<MODELs>::value>::check();//check submodels models individually
         }
-
 
         //coupled model full assert check
         template<typename FLOATING_MODEL>
@@ -226,6 +221,7 @@ namespace cadmium {
             //check submodels when using float as TIME
             using floating_submodels=typename FLOATING_MODEL::template models<float>;
             static_assert(std::is_constructible<floating_submodels>::value, "coupled model cannot be constructed");
+            assert_submodels<floating_submodels>();
         }
 
         template<template<typename TIME> class MODEL>
@@ -234,6 +230,7 @@ namespace cadmium {
             using floating_model=MODEL<float>;
             coupled_model_float_time_assert<floating_model>();
         }
+
     }
 }
 #endif // CADMIUM_COUPLED_MODEL_ASSERT_HPP

--- a/include/cadmium/engine/pdevs_simulator.hpp
+++ b/include/cadmium/engine/pdevs_simulator.hpp
@@ -90,7 +90,7 @@ namespace cadmium {
                 LOGGER::template log<cadmium::logger::logger_info, cadmium::logger::sim_info_init>(initial_time, _model_id);
 
                 _last=initial_time;
-                cadmium::concept::pdevs_atomic_model_assert<MODEL>();
+                concept::pdevs::atomic_model_assert<MODEL>();
                 _next = initial_time + _model.time_advance();
 
                 LOGGER::template log<cadmium::logger::logger_state, cadmium::logger::sim_state>(model_state, _model_id);

--- a/include/cadmium/modeling/coupling.hpp
+++ b/include/cadmium/modeling/coupling.hpp
@@ -134,7 +134,7 @@ namespace cadmium::modeling {
             using external_input_couplings=EICs;
             using external_output_couplings=EOCs;
             using internal_couplings=ICs;
-            using select=SELECT; //This is false if PDEVS
+            using select=SELECT;
         };
 
     }

--- a/include/cadmium/modeling/dynamic_atomic.hpp
+++ b/include/cadmium/modeling/dynamic_atomic.hpp
@@ -71,7 +71,7 @@ namespace cadmium {
 
                 atomic() {
                     static_assert(cadmium::concept::is_atomic<ATOMIC>::value, "This is not an atomic model");
-                    cadmium::concept::pdevs_atomic_model_assert<ATOMIC>();
+                    cadmium::concept::pdevs::atomic_model_assert<ATOMIC>();
                     _id = boost::typeindex::type_id<model_type>().pretty_name();
                     _input_ports = cadmium::dynamic::modeling::create_dynamic_ports<input_ports>();
                     _output_ports = cadmium::dynamic::modeling::create_dynamic_ports<output_ports>();
@@ -79,7 +79,7 @@ namespace cadmium {
 
                 atomic(const std::string& model_id, Args&&... args) : ATOMIC<TIME>(std::forward<Args>(args)...) {
                     static_assert(cadmium::concept::is_atomic<ATOMIC>::value, "This is not an atomic model");
-                    cadmium::concept::pdevs_atomic_model_assert<ATOMIC>();
+                    cadmium::concept::pdevs::atomic_model_assert<ATOMIC>();
                     _id = model_id;
                     _input_ports = cadmium::dynamic::modeling::create_dynamic_ports<input_ports>();
                     _output_ports = cadmium::dynamic::modeling::create_dynamic_ports<output_ports>();

--- a/test-compile/compile-fails/pdevs_inports_not_a_tuple_in_atomic_model_fail_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_inports_not_a_tuple_in_atomic_model_fail_compile_test.cpp
@@ -63,5 +63,5 @@ struct pdevs_atomic_model_with_inputs_as_vector {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<pdevs_atomic_model_with_inputs_as_vector>();
+    cadmium::concept::pdevs::atomic_model_assert<pdevs_atomic_model_with_inputs_as_vector>();
 }

--- a/test-compile/compile-fails/pdevs_missing_confluence_transition_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_confluence_transition_fails_compile_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -55,5 +56,5 @@ struct atomic_model_missing_confluence_function
 };
 
 int main(){
-    cadmium::concept::pdevs_atomic_model_assert<atomic_model_missing_confluence_function>();
+    cadmium::concept::pdevs::atomic_model_assert<atomic_model_missing_confluence_function>();
 }

--- a/test-compile/compile-fails/pdevs_missing_external_transition_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_external_transition_fails_compile_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -60,5 +61,5 @@ struct pdevs_atomic_model_missing_external_function {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<pdevs_atomic_model_missing_external_function>();
+    cadmium::concept::pdevs::atomic_model_assert<pdevs_atomic_model_missing_external_function>();
 }

--- a/test-compile/compile-fails/pdevs_missing_input_ports_in_atomic_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_input_ports_in_atomic_fails_compile_test.cpp
@@ -34,6 +34,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests.
  * In this case it is missing the declaration of input_ports type
@@ -62,5 +63,5 @@ struct pdevs_atomic_model_with_no_input_ports {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<pdevs_atomic_model_with_no_input_ports>();
+    cadmium::concept::pdevs::atomic_model_assert<pdevs_atomic_model_with_no_input_ports>();
 }

--- a/test-compile/compile-fails/pdevs_missing_internal_transition_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_internal_transition_fails_compile_test.cpp
@@ -60,5 +60,5 @@ struct devs_atomic_model_with_no_internal_transition {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_with_no_internal_transition>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_with_no_internal_transition>();
 }

--- a/test-compile/compile-fails/pdevs_missing_output_function_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_output_function_fails_compile_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -60,5 +61,5 @@ struct devs_atomic_model_missing_output_function {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_missing_output_function>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_missing_output_function>();
 }

--- a/test-compile/compile-fails/pdevs_missing_output_ports_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_output_ports_fails_compile_test.cpp
@@ -34,6 +34,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests.
  * In this case it is missing the declaration of input_ports type
@@ -62,5 +63,5 @@ struct devs_atomic_model_with_no_output_ports {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_with_no_output_ports>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_with_no_output_ports>();
 }

--- a/test-compile/compile-fails/pdevs_missing_state_type_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_state_type_fails_compile_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -61,5 +62,5 @@ struct devs_atomic_model_missing_state_type_declaration {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_missing_state_type_declaration>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_missing_state_type_declaration>();
 }

--- a/test-compile/compile-fails/pdevs_missing_state_variable_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_state_variable_fails_compile_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -62,5 +63,5 @@ struct devs_atomic_model_missing_state_variable {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_missing_state_variable>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_missing_state_variable>();
 }

--- a/test-compile/compile-fails/pdevs_missing_time_advance_function_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_missing_time_advance_function_fails_compile_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_box.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -61,5 +62,5 @@ struct devs_atomic_model_missing_time_advance_function {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_missing_time_advance_function>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_missing_time_advance_function>();
 }

--- a/test-compile/compile-fails/pdevs_outports_not_a_tuple_in_atomic_model_fail_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_outports_not_a_tuple_in_atomic_model_fail_compile_test.cpp
@@ -34,6 +34,7 @@
 #include<cadmium/modeling/message_bag.hpp>
 #include<vector>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -63,5 +64,5 @@ struct devs_atomic_model_with_outputs_as_vector {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_with_outputs_as_vector>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_with_outputs_as_vector>();
 }

--- a/test-compile/compile-fails/pdevs_outports_not_a_tuple_in_coupled_model_fail_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_outports_not_a_tuple_in_coupled_model_fail_compile_test.cpp
@@ -28,7 +28,6 @@
 #include <vector>
 #include <cadmium/modeling/coupling.hpp>
 #include <cadmium/concept/coupled_model_assert.hpp>
-#include "coupled_model.hpp"
 
 /**
  * Test that when output ports of a coupled model are not defined as a tuple, coupling fails compilation
@@ -45,6 +44,6 @@ template<typename TIME>
 using C1=cadmium::modeling::pdevs::coupled_model<TIME, input_ports, output_ports, submodels, EICs, EOCs, ICs>;
 
 int main(){
-    cadmium::concept::coupled_model_assert<C1>();
+    cadmium::concept::pdevs::coupled_model_assert<C1>();
     return 0;
 }

--- a/test-compile/compile-fails/pdevs_repeated_input_ports_fail_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_repeated_input_ports_fail_compile_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * Test that when an atomic model has duplicated input ports, atomic_model_assert fails compilation
  */
@@ -65,5 +66,5 @@ struct devs_atomic_model_with_repeated_input_ports {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_with_repeated_input_ports>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_with_repeated_input_ports>();
 }

--- a/test-compile/compile-fails/pdevs_repeated_output_ports_fail_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_repeated_output_ports_fail_compile_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
 * Test that when an atomic model has duplicated output ports, atomic_model_assert fails compilation */
 template<typename TIME>
@@ -64,5 +65,5 @@ struct devs_atomic_model_with_repeated_output_ports {
 };
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<devs_atomic_model_with_repeated_output_ports>();
+    cadmium::concept::pdevs::atomic_model_assert<devs_atomic_model_with_repeated_output_ports>();
 }

--- a/test-compile/compile-fails/pdevs_submodel_is_not_a_model_fails_compile_test.cpp
+++ b/test-compile/compile-fails/pdevs_submodel_is_not_a_model_fails_compile_test.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013-2016, Damian Vicino
+ * Copyright (c) 2013-2019, Damian Vicino
  * Carleton University, Universite de Nice-Sophia Antipolis
  * All rights reserved.
  *
@@ -27,30 +27,29 @@
 /**
  * Test that failing to declare valid submodels in a coupled model fails compilation
  */
-#include<cadmium/modeling/coupled_model.hpp>
+#include<cadmium/modeling/coupling.hpp>
 #include<cadmium/concept/coupled_model_assert.hpp>
 
+using input_ports_c1=std::tuple<>;
+using output_ports_c1=std::tuple<>;
+using submodels_c1 = cadmium::modeling::models_tuple<>;
+using EICs_c1 = std::tuple<>;
+using EOCs_c1 = std::tuple<>;
+using ICs_c1 = std::tuple<int>; //C1 is not a valid coupled model
+template<typename TIME>
+using C1=cadmium::modeling::pdevs::coupled_model<TIME, input_ports_c1, output_ports_c1, submodels_c1, EICs_c1, EOCs_c1, ICs_c1>;
+
+//C2 has C1 as submodel
+using input_ports=std::tuple<>;
+using output_ports=std::tuple<>;
+using submodels = cadmium::modeling::models_tuple<C1>;
+using EICs = std::tuple<>;
+using EOCs = std::tuple<>;
+using ICs = std::tuple<>;
+template<typename TIME>
+using C2=cadmium::modeling::pdevs::coupled_model<TIME, input_ports, output_ports, submodels, EICs, EOCs, ICs>;
+
 int main(){
-
-    using input_ports_c1=std::tuple<>;
-    using output_ports_c1=std::tuple<>;
-    using submodels_c1 = cadmium::modeling::models_tuple<>;
-    using EICs_c1 = std::tuple<>;
-    using EOCs_c1 = std::tuple<>;
-    using ICs_c1 = std::tuple<int>; //C1 is not a valid coupled model
-    using C1=cadmium::modeling::coupled_model<input_ports_c1, output_ports_c1, submodels_c1, EICs_c1, EOCs_c1, ICs_c1>;
-
-    //C2 has C1 as submodel
-    using input_ports=std::tuple<>;
-    using output_ports=std::tuple<>;
-
-    using submodels = cadmium::modeling::models_tuple<C1>;
-    using EICs = std::tuple<>;
-    using EOCs = std::tuple<>;
-    using ICs = std::tuple<>;
-    using C2=cadmium::modeling::coupled_model<input_ports, output_ports, submodels, EICs, EOCs, ICs>;
-
-    cadmium::concept::coupled_model_assert<C2>();
-
+    cadmium::concept::pdevs::coupled_model_assert<C2>();
     return 0;
 }

--- a/test-compile/compiles/devs_generator_atomic_check_test.cpp
+++ b/test-compile/compiles/devs_generator_atomic_check_test.cpp
@@ -48,5 +48,5 @@ struct floating_generator : public floating_generator_base<TIME> {
 
 
 int main(){
-    cadmium::concept::devs_atomic_model_assert<floating_generator>();
+    cadmium::concept::devs::atomic_model_assert<floating_generator>();
 }

--- a/test-compile/compiles/devs_passive_atomic_check_test.cpp
+++ b/test-compile/compiles/devs_passive_atomic_check_test.cpp
@@ -37,5 +37,5 @@ template<typename TIME>
 using floating_passive=cadmium::basic_models::devs::passive<float, TIME>;
 
 int main(){
-    cadmium::concept::devs_atomic_model_assert<floating_passive>();
+    cadmium::concept::devs::atomic_model_assert<floating_passive>();
 }

--- a/test-compile/compiles/pdevs_coupled_of_all_atomics_test.cpp
+++ b/test-compile/compiles/pdevs_coupled_of_all_atomics_test.cpp
@@ -29,8 +29,9 @@
  */
 
 #include "pdevs_coupled_of_atomic_models.hpp"
+#include <cadmium/concept/coupled_model_assert.hpp>
 
 int main(){
-    cadmium::concept::coupled_model_assert<coupled_of_atomics>();
+    cadmium::concept::pdevs::coupled_model_assert<coupled_of_atomics>();
     return 0;
 }

--- a/test-compile/compiles/pdevs_coupled_of_all_coupleds_test.cpp
+++ b/test-compile/compiles/pdevs_coupled_of_all_coupleds_test.cpp
@@ -28,11 +28,11 @@
  * Test that asserting coupled model with all submodels atomic does not fail compilation
  */
 
+#include <tuple>
+
 #include <cadmium/modeling/ports.hpp>
 #include <cadmium/modeling/coupling.hpp>
 #include <cadmium/concept/coupled_model_assert.hpp>
-#include <tuple>
-
 #include <cadmium/basic_model/pdevs/passive.hpp>
 
 using namespace cadmium;
@@ -90,6 +90,6 @@ using C_top=cadmium::modeling::pdevs::coupled_model<TIME, input_ports_top, outpu
 
 
 int main() {
-    cadmium::concept::coupled_model_assert<C_top>();
+    cadmium::concept::pdevs::coupled_model_assert<C_top>();
     return 0;
 }

--- a/test-compile/compiles/pdevs_coupled_of_mixed_models_test.cpp
+++ b/test-compile/compiles/pdevs_coupled_of_mixed_models_test.cpp
@@ -29,8 +29,9 @@
  */
 
 #include "pdevs_coupled_of_mixed_models.hpp"
+#include <cadmium/concept/coupled_model_assert.hpp>
 
 int main(){
-    cadmium::concept::coupled_model_assert<coupled_of_mixed_models>();
+    cadmium::concept::pdevs::coupled_model_assert<coupled_of_mixed_models>();
     return 0;
 }

--- a/test-compile/compiles/pdevs_empty_coupled_model_is_a_valid_model_test.cpp
+++ b/test-compile/compiles/pdevs_empty_coupled_model_is_a_valid_model_test.cpp
@@ -29,7 +29,9 @@
  */
 #include <cadmium/concept/coupled_model_assert.hpp>
 #include "pdevs_empty_coupled_model.hpp"
+
+
 int main(){
-    cadmium::concept::coupled_model_assert<pdevs_empty_coupled_model::type>();
+    cadmium::concept::pdevs::coupled_model_assert<pdevs_empty_coupled_model::type>();
     return 0;
 }

--- a/test-compile/compiles/pdevs_generator_atomic_check_test.cpp
+++ b/test-compile/compiles/pdevs_generator_atomic_check_test.cpp
@@ -32,6 +32,7 @@
 #include<cadmium/concept/atomic_model_assert.hpp>
 #include<cadmium/basic_model/pdevs/generator.hpp>
 
+
 //preparing the generator to be used as atomic model
 template<typename TIME>
 using floating_generator_base=cadmium::basic_models::pdevs::generator<float, TIME>;
@@ -49,5 +50,5 @@ struct floating_generator : public floating_generator_base<TIME> {
 
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<floating_generator>();
+    cadmium::concept::pdevs::atomic_model_assert<floating_generator>();
 }

--- a/test-compile/compiles/pdevs_passive_atomic_check_test.cpp
+++ b/test-compile/compiles/pdevs_passive_atomic_check_test.cpp
@@ -37,5 +37,5 @@ template<typename TIME>
 using floating_passive=cadmium::basic_models::pdevs::passive<float, TIME>;
 
 int main() {
-    cadmium::concept::pdevs_atomic_model_assert<floating_passive>();
+    cadmium::concept::pdevs::atomic_model_assert<floating_passive>();
 }

--- a/test-compile/compiles/pdevs_valid_atomic_check_test.cpp
+++ b/test-compile/compiles/pdevs_valid_atomic_check_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -56,5 +57,5 @@ struct valid_atomic_model
 };
 
 int main(){
-    cadmium::concept::pdevs_atomic_model_assert<valid_atomic_model>();
+    cadmium::concept::pdevs::atomic_model_assert<valid_atomic_model>();
 }

--- a/test-compile/compiles/pdevs_valid_atomic_with_multiple_ports_check_test.cpp
+++ b/test-compile/compiles/pdevs_valid_atomic_with_multiple_ports_check_test.cpp
@@ -33,6 +33,7 @@
 #include<tuple>
 #include<cadmium/modeling/message_bag.hpp>
 
+
 /**
  * This model has no logic, only used for structural validation tests
  */
@@ -60,5 +61,5 @@ struct valid_atomic_with_multiple_ports
 };
 
 int main(){
-    cadmium::concept::pdevs_atomic_model_assert<valid_atomic_with_multiple_ports>();
+    cadmium::concept::pdevs::atomic_model_assert<valid_atomic_with_multiple_ports>();
 }


### PR DESCRIPTION
There was a bug on the fail-compile tests that prevented to detect that the coupled_assert didn't follow the recursive step on validating the submodels.
- Fixed the tests to fail in the right scenario.
- Fixed the assert so it works as expected taking the recursive step.
- Renamed some functions to make explicit it is PDEVS related

TODO: This comes because fail-compile test do no validate that the reason the compile fails is the expected one, we should improve the validation step of those tests. This need some thinking before deciding how to do it. 