### PR TITLE
release 0.2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ matrix:
       compiler: gcc
       addons:
           apt:
-              packages: lcov
+              update: true
+              packages: 
+              - cmake
+              - lcov
       before_install:
           # C++17
           - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.6.1)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum OS X deployment version")
 project(
     cadmium
-    VERSION 0.2.7)
+    VERSION 0.2.8)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake-modules")
 

--- a/cadmiumConfig.cmake.in
+++ b/cadmiumConfig.cmake.in
@@ -1,2 +1,1 @@
 @PACKAGE_INIT@
-include( "$CMAKE_CURRENT_LIST_DIR}/cadmium.cmake" )


### PR DESCRIPTION
Removing missing file from been included in cmake.
Travis failure seems related to usage of old cmake, going to force an upgrade in next commit.