### PR TITLE
Cell-DEVS configuration now uses merge patch

### DIFF
--- a/example/celldevs/pandemic_hoya/scenario.json
+++ b/example/celldevs/pandemic_hoya/scenario.json
@@ -36,10 +36,14 @@
     },
     "epicenter": {
       "state": {
-        "population": 100,
         "susceptible": 0.7,
-        "infected": 0.3,
-        "recovered": 0
+        "infected": 0.3
+      }
+    },
+    "recovered": {
+      "state": {
+        "susceptible": 0,
+        "recovered": 1
       }
     },
     "immune": {

--- a/include/cadmium/celldevs/cell/cell.hpp
+++ b/include/cadmium/celldevs/cell/cell.hpp
@@ -51,9 +51,8 @@ namespace cadmium::celldevs {
     template <typename C, typename S>
     struct cell_ports_def{
         struct [[maybe_unused]] cell_in: public cadmium::in_port<cell_state_message<C, S>> {};
-        struct cell_out : public cadmium::out_port<cell_state_message<C, S>> {};
+        struct [[maybe_unused]] cell_out : public cadmium::out_port<cell_state_message<C, S>> {};
     };
-
 
     /**
      * Abstract DEVS atomic model for defining cells in extended Cell-DEVS scenarios.

--- a/include/cadmium/celldevs/coupled/cells_coupled.hpp
+++ b/include/cadmium/celldevs/coupled/cells_coupled.hpp
@@ -189,7 +189,7 @@ namespace cadmium::celldevs {
                                 ? parse_neighborhood(description["neighborhood"]) : default_config.neighborhood;
             auto config = default_config.config;
             if (description.contains("config")) {  // If a patch exists, we try to apply it
-                config = cadmium::json::parse(default_config.config.dump());  // deep copy of default state
+                config = cadmium::json::parse(config.dump());
                 config.merge_patch(description["config"]);
             }
             return cell_config<C, S, V>(delay, cell_type, state, neighborhood, config);

--- a/include/cadmium/celldevs/coupled/grid_coupled.hpp
+++ b/include/cadmium/celldevs/coupled/grid_coupled.hpp
@@ -130,12 +130,17 @@ namespace cadmium::celldevs {
             for (const cadmium::json &n: j) {
                 auto type = n["type"].get<std::string>();
                 auto vicinity = n["vicinity"].get<V>();
-                if (type == "custom") {  // TODO change "custom" to "relative"
+                if (type == "custom" || type == "relative") {
+                    if (type == "custom") {
+                        std::cerr << "Deprecation warning: \"custom\" neighborhood type has been changed to \"relative\". Change it in your JSON configuration file.\n";
+                    }
                     for (const cadmium::json &relative: n["neighbors"]) {
                         auto neighbor = relative.get<cell_position>();
                         neighborhood[neighbor] = vicinity;
                     }
-                } else {  // TODO add "absolute" and "remove" neighborhoods
+                } else if (type == "absolute" || type == "remove") {
+                    throw std::logic_error("Neighborhood type not yet implemented");  // TODO implement these neighborhood types
+                } else {
                     auto range = (n.contains("range")) ? n["range"].get<int>() : 1;
                     std::vector<cell_position> neighbors;
                     if (type == "von_neumann") {

--- a/include/cadmium/celldevs/coupled/grid_coupled.hpp
+++ b/include/cadmium/celldevs/coupled/grid_coupled.hpp
@@ -37,6 +37,7 @@
 #include <cadmium/modeling/dynamic_model_translator.hpp>
 #include <cadmium/celldevs/coupled/cells_coupled.hpp>
 #include <cadmium/celldevs/cell/grid_cell.hpp>
+#include <cadmium/celldevs/utils/utils.hpp>
 #include <cadmium/celldevs/utils/grid_utils.hpp>
 #include <cadmium/json/json.hpp>
 
@@ -55,9 +56,8 @@ namespace cadmium::celldevs {
         cell_position shape = cell_position();
         bool wrapped = false;
     public:
-
-        using cell_config_map = std::unordered_map<std::string, cell_config<S, V>>;
-
+        using cells_coupled<T, cell_position, S, V>::default_config_json;
+        using cells_coupled<T, cell_position, S, V>::get_default_configs;
         using cells_coupled<T, cell_position, S, V>::get_cell_name;
         using cells_coupled<T, cell_position, S, V>::add_cell;
         using cells_coupled<T, cell_position, S, V>::add_cell_neighborhood;
@@ -105,6 +105,7 @@ namespace cadmium::celldevs {
             shape = j["shape"].get<cell_position>();
             wrapped = j.contains("wrapped") && j["wrapped"].get<bool>();
             // Read cell configurations and create default scenario
+            default_config_json = j["cells"]["default"];
             auto default_configs = get_default_configs(j["cells"]);
             grid_scenario<S, V> scenario = grid_scenario<S, V>(shape, default_configs.at("default"), wrapped);
             // Set special configurations
@@ -124,51 +125,17 @@ namespace cadmium::celldevs {
             }
         }
 
-        cell_config_map get_default_configs(const cadmium::json &cells_config) {
-            auto default_configs = cell_config_map({{"default", read_default_cell_config(cells_config["default"])}});
-            for (auto &el: cells_config.items()) {
-                const auto &config_id = el.key();
-                auto config_val = el.value();
-                if (config_id == "default") {
-                    continue;
-                }
-                default_configs[config_id] = read_cell_config(config_val, default_configs.at("default"));
-            }
-            return default_configs;
-        }
-
-        cell_config<S, V> read_default_cell_config(cadmium::json const &description) {
-            auto delay = description["delay"].get<std::string>();
-            auto cell_type = description["cell_type"].get<std::string>();
-            auto state = (description.contains("state")) ? description["state"].get<S>() : S();
-            auto neighborhood = (description.contains("neighborhood"))
-                    ? parse_neighborhood(description["neighborhood"]) : cell_unordered<V>();
-            auto config = (description.contains("config")) ? description["config"] : cadmium::json();
-            return cell_config<S, V>(delay, cell_type, state, neighborhood, config);
-        }
-
-        cell_config<S, V> read_cell_config(cadmium::json const &description, cell_config<S, V> const &default_config) {
-            auto delay = (description.contains("delay")) ? description["delay"].get<std::string>() : default_config.delay;
-            auto cell_type = (description.contains("cell_type")) ? description["cell_type"].get<std::string>()
-                                                                : default_config.cell_type;
-            auto state = (description.contains("state")) ? description["state"].get<S>() : default_config.state;
-            auto neighborhood = (description.contains("neighborhood"))
-                    ? parse_neighborhood(description["neighborhood"]) : default_config.neighborhood;
-            auto config = (description.contains("config")) ? description["config"] : default_config.config;
-            return cell_config<S, V>(delay, cell_type, state, neighborhood, config);
-        }
-
-        cell_unordered<V> parse_neighborhood(const cadmium::json &j) {
+        cell_unordered<V> parse_neighborhood(const cadmium::json &j) override {
             auto neighborhood = cell_unordered< V>();
             for (const cadmium::json &n: j) {
                 auto type = n["type"].get<std::string>();
                 auto vicinity = n["vicinity"].get<V>();
-                if (type == "custom") {
+                if (type == "custom") {  // TODO change "custom" to "relative"
                     for (const cadmium::json &relative: n["neighbors"]) {
                         auto neighbor = relative.get<cell_position>();
                         neighborhood[neighbor] = vicinity;
                     }
-                } else {
+                } else {  // TODO add "absolute" and "remove" neighborhoods
                     auto range = (n.contains("range")) ? n["range"].get<int>() : 1;
                     std::vector<cell_position> neighbors;
                     if (type == "von_neumann") {

--- a/include/cadmium/celldevs/utils/grid_utils.hpp
+++ b/include/cadmium/celldevs/utils/grid_utils.hpp
@@ -36,8 +36,8 @@
 #include <cassert>
 #include <exception>
 #include <cmath>
-#include <cadmium/celldevs/utils/utils.hpp>
 #include <boost/functional/hash.hpp>
+#include <cadmium/celldevs/utils/utils.hpp>
 
 
 namespace cadmium::celldevs {
@@ -57,18 +57,7 @@ namespace cadmium::celldevs {
      * @tparam V type used to represent vicinities between cells.
      */
     template <typename S, typename V>
-    struct cell_config {
-        std::string delay;                  /// ID of the delay buffer of the cell.
-        std::string cell_type;              /// Cell model type.
-        S state;                            /// Initial state of the cell.
-        cell_unordered<V> neighborhood;     /// Unordered map {neighbor_cell_position: vicinity}.
-        nlohmann::json config;              /// JSON file with additional configuration parameters.
-
-        cell_config() {};
-
-        cell_config(std::string delay, std::string cell_type, const S &state, const cell_unordered<V> &neighborhood, nlohmann::json config):
-                delay(std::move(delay)), cell_type(std::move(cell_type)), state(state), neighborhood(neighborhood), config(std::move(config)) {}
-    };
+    using grid_cell_config = cell_config<cell_position, S, V>;
 
     /**
      * Auxiliary class with useful functions for grid cells.
@@ -110,13 +99,13 @@ namespace cadmium::celldevs {
     template<typename S, typename V>
     class grid_scenario {
     public:
-        cell_position shape;                        /// Shape of the scenario.
-        unsigned int dimension;                     /// Dimension of the grid of the scenario.
-        cell_unordered<cell_config<S, V>> configs;  /// Configuration of cells in the grid.
-        bool wrapped;                               /// It indicates whether the scenario is wrapped or not.
+        cell_position shape;                             /// Shape of the scenario.
+        unsigned int dimension;                          /// Dimension of the grid of the scenario.
+        cell_unordered<grid_cell_config<S, V>> configs;  /// Configuration of cells in the grid.
+        bool wrapped;                                    /// It indicates whether the scenario is wrapped or not.
 
-        void set_initial_config(const cell_config<S, V> &config) {
-            configs = cell_unordered<cell_config<S, V>>();
+        void set_initial_config(const grid_cell_config<S, V> &config) {
+            configs = cell_unordered<grid_cell_config<S, V>>();
             cell_position current = cell_position();
             for (int i = 0; i < dimension; i++)
                 current.push_back(0);
@@ -130,12 +119,12 @@ namespace cadmium::celldevs {
             }
         }
 
-        void set_initial_config(const cell_position &cell, const cell_config<S, V> config) {
+        void set_initial_config(const cell_position &cell, const grid_cell_config<S, V> config) {
             assert(cell_in_scenario(cell));
             configs[cell] = config;
         }
 
-        grid_scenario(const cell_position &shape, const cell_config<S, V> &config, bool wrapped):
+        grid_scenario(const cell_position &shape, const grid_cell_config<S, V> &config, bool wrapped):
         shape(shape), dimension(shape.size()), configs(), wrapped(wrapped) {
             // Assert that the shape of the scenario is well-defined
             set_initial_config(config);

--- a/include/cadmium/celldevs/utils/utils.hpp
+++ b/include/cadmium/celldevs/utils/utils.hpp
@@ -35,6 +35,7 @@
 #include <functional>
 #include <unordered_map>
 #include <nlohmann/json.hpp>
+#include <cadmium/json/json.hpp>
 #include <boost/functional/hash.hpp>
 
 /**
@@ -65,5 +66,30 @@ template <typename SEQ>
 /// Specialization of std::hash function for vectors
 template<typename X>
 struct [[maybe_unused]] std::hash<std::vector<X>> : boost::hash<std::vector<X>> {};
+
+
+namespace cadmium::celldevs {
+    /**
+     * Cell configuration structure.
+     * @tparam C type used to represent cell IDs.
+     * @tparam S type used to represent cell states.
+     * @tparam V type used to represent vicinities between cells.
+     */
+    template<typename C, typename S, typename V>
+    struct cell_config {
+        std::string delay;                      /// ID of the delay buffer of the cell.
+        std::string cell_type;                  /// Cell model type.
+        S state;                                /// Initial state of the cell.
+        std::unordered_map<C, V> neighborhood;  /// Unordered map {neighbor_cell_position: vicinity}.
+        cadmium::json config;                   /// JSON file with additional configuration parameters.
+
+        cell_config() = default;
+
+        cell_config(std::string delay, std::string cell_type, const S &state,
+                    const std::unordered_map<C, V> &neighborhood, cadmium::json config) :
+                delay(std::move(delay)), cell_type(std::move(cell_type)), state(state), neighborhood(neighborhood),
+                config(std::move(config)) {}
+    };
+}  // namespace cadmium::celldevs
 
 #endif //CADMIUM_CELLDEVS_UTILS_HPP

--- a/include/cadmium/celldevs/utils/utils.hpp
+++ b/include/cadmium/celldevs/utils/utils.hpp
@@ -34,7 +34,6 @@
 #include <iostream>
 #include <functional>
 #include <unordered_map>
-#include <nlohmann/json.hpp>
 #include <cadmium/json/json.hpp>
 #include <boost/functional/hash.hpp>
 

--- a/test/celldevs_grid_utils_test.cpp
+++ b/test/celldevs_grid_utils_test.cpp
@@ -72,31 +72,3 @@ BOOST_AUTO_TEST_CASE(von_neumann) {
         }
     }
 }
-
-BOOST_AUTO_TEST_CASE(grid_test_2d) {
-    cell_position scenario_shape = {10, 10};
-
-    grid_scenario space = grid_scenario<int, int>(scenario_shape, 0, true);
-    space.set_initial_state({0, 0}, 1);
-    space.set_von_neumann_neighborhood(1);
-    cell_unordered<int> neighbors = space.get_vicinities();
-    BOOST_CHECK(!space.cell_in_scenario({10, 10}));
-    BOOST_CHECK(!space.cell_in_scenario({-1, 0}));
-    BOOST_CHECK(space.cell_in_scenario({0, 9}));
-    BOOST_CHECK(space.cell_in_scenario({0, 0}));
-    cell_position ref = {0, 0};
-    cell_map<int, int> neighborhood = space.get_cell_map(ref);
-    BOOST_CHECK_EQUAL(neighborhood.neighborhood.size(), space.get_vicinities().size());
-    for (auto &cell_mapping: neighborhood.neighborhood) {
-        BOOST_CHECK_LT(space.manhattan_distance(ref, cell_mapping.first), 2);
-    }
-
-    space = grid_scenario(scenario_shape, 0, neighbors, false);
-    neighborhood = space.get_cell_map(ref);
-    BOOST_CHECK_NE(neighborhood.neighborhood.size(), space.get_vicinities().size());
-    for (auto &cell_mapping: neighborhood.neighborhood) {
-        BOOST_CHECK_LT(space.manhattan_distance(ref, cell_mapping.first), 2);
-    }
-    ref = {3, 3};
-    cell_map<int, int> cell_u = space.get_cell_map(ref);
-}


### PR DESCRIPTION
Now, users only need to define state and configuration differences instead of the entire JSON block.
Additionally, `"custom"` neighborhood types have been renamed to `"relative"`. The `"custom"` type is still supported, but it prints a warning message.