### PR TITLE
Progress Meter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ example/celldevs/simulation_results/
 # JSON
 json/
 !include/cadmium/json
+
+# VSCode
+.vscode

--- a/include/cadmium/concept/concept_helpers.hpp
+++ b/include/cadmium/concept/concept_helpers.hpp
@@ -61,7 +61,7 @@ namespace cadmium {
             struct check_unique_elem_types_impl {
                 static constexpr bool value() {
                     using elem=typename std::tuple_element<S - 1, T>::type;
-                    std::get<elem>(T{});
+                    (void) std::get<elem>(T{});
                     return check_unique_elem_types_impl<T, S - 1>::value();
                 }
             };

--- a/include/cadmium/engine/pdevs_dynamic_runner.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_runner.hpp
@@ -61,7 +61,7 @@ namespace cadmium {
             class runner {
                 TIME _next; //next scheduled event
 
-                bool progressBar = false;
+                bool progress_bar = false;
 
                 cadmium::dynamic::engine::coordinator<TIME, LOGGER> _top_coordinator; //this only works for coupled models.
 
@@ -123,8 +123,8 @@ namespace cadmium {
                         _top_coordinator.advance_simulation(_next);
                         _next = _top_coordinator.next();
 
-                        if (progressBar)
-                            progress_bar(_next, t);
+                        if (progress_bar)
+                            progress_bar_meter(_next, t);
                     }
 
                     turn_progress_off();
@@ -146,11 +146,11 @@ namespace cadmium {
                  * @param current Current time step
                  * @param total Maximum timestep (can be infinity)
                  */
-                void progress_bar(int current, int total)
+                void progress_bar_meter(TIME current, TIME total)
                 {
                     std::cout << "\r[" << current << "/";
 
-                    if (total == (int)std::numeric_limits<TIME>::infinity())
+                    if (total == std::numeric_limits<TIME>::infinity())
                         std::cout << "inf]";
                     else
                         std::cout << total << "]";
@@ -158,8 +158,8 @@ namespace cadmium {
                     std::cout << std::flush;
                 }
 
-                void turn_progress_on()  { progressBar = true;  std::cout << "\033[33m" << std::flush;  }
-                void turn_progress_off() { progressBar = false; std::cout << "\033[0m"  << std::flush;  }
+                void turn_progress_on()  { progress_bar = true;  std::cout << "\033[33m" << std::flush;  }
+                void turn_progress_off() { progress_bar = false; std::cout << "\033[0m"  << std::flush;  }
             };
         }
     }

--- a/include/cadmium/engine/pdevs_dynamic_runner.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_runner.hpp
@@ -148,18 +148,18 @@ namespace cadmium {
                  */
                 void progress_bar(int current, int total)
                 {
-                    cout << "\r[" << current << "/";
+                    std::cout << "\r[" << current << "/";
 
                     if (total == (int)std::numeric_limits<TIME>::infinity())
-                        cout << "inf]";
+                        std::cout << "inf]";
                     else
-                        cout << total << "]";
+                        std::cout << total << "]";
 
-                    cout << flush;
+                    std::cout << std::flush;
                 }
 
-                void turn_progress_on()  { progressBar = true;  cout << "\033[33m" << flush;  }
-                void turn_progress_off() { progressBar = false; cout << "\033[0m"  << flush;  }
+                void turn_progress_on()  { progressBar = true;  std::cout << "\033[33m" << std::flush;  }
+                void turn_progress_off() { progressBar = false; std::cout << "\033[0m"  << std::flush;  }
             };
         }
     }

--- a/include/cadmium/engine/pdevs_dynamic_runner.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_runner.hpp
@@ -61,6 +61,8 @@ namespace cadmium {
             class runner {
                 TIME _next; //next scheduled event
 
+                bool progressBar = false;
+
                 cadmium::dynamic::engine::coordinator<TIME, LOGGER> _top_coordinator; //this only works for coupled models.
 
                 #ifdef CADMIUM_EXECUTE_CONCURRENT
@@ -120,7 +122,12 @@ namespace cadmium {
                         _top_coordinator.collect_outputs(_next);
                         _top_coordinator.advance_simulation(_next);
                         _next = _top_coordinator.next();
+
+                        if (progressBar)
+                            progress_bar(_next, t);
                     }
+
+                    turn_progress_off();
                     LOGGER::template log<cadmium::logger::logger_info, cadmium::logger::run_info>("Finished run");
                     return _next;
                 }
@@ -131,6 +138,28 @@ namespace cadmium {
                 void run_until_passivate() {
                     run_until(std::numeric_limits<TIME>::infinity());
                 }
+
+                /**
+                 * @brief Displays current progress of simulation
+                 *  e.g., [50/500]
+                 * 
+                 * @param current Current time step
+                 * @param total Maximum timestep (can be infinity)
+                 */
+                void progress_bar(int current, int total)
+                {
+                    cout << "\r[" << current << "/";
+
+                    if (total == (int)std::numeric_limits<TIME>::infinity())
+                        cout << "inf]";
+                    else
+                        cout << total << "]";
+
+                    cout << flush;
+                }
+
+                void turn_progress_on()  { progressBar = true;  cout << "\033[33m" << flush;  }
+                void turn_progress_off() { progressBar = false; cout << "\033[0m"  << flush;  }
             };
         }
     }

--- a/include/cadmium/modeling/dynamic_atomic.hpp
+++ b/include/cadmium/modeling/dynamic_atomic.hpp
@@ -78,7 +78,7 @@ namespace cadmium {
                 }
 
                 atomic(const std::string& model_id, Args&&... args) : ATOMIC<TIME>(std::forward<Args>(args)...) {
-                    static_assert(cadmium::concept::is_atomic<ATOMIC>::value(), "This is not an atomic model");
+                    static_assert((bool)cadmium::concept::is_atomic<ATOMIC>::value, "This is not an atomic model");
                     cadmium::concept::pdevs::atomic_model_assert<ATOMIC>();
                     _id = model_id;
                     _input_ports = cadmium::dynamic::modeling::create_dynamic_ports<input_ports>();


### PR DESCRIPTION
Added the option to turn on a progress meter (off by default). Below are two examples of what it looks like in practice. It's only what's in yellow at the very bottom.
![500](https://user-images.githubusercontent.com/59673626/129586090-0609f4e6-4268-4184-aac4-38444af9df3c.png)
![inf](https://user-images.githubusercontent.com/59673626/129586214-1082aea0-003a-4f12-a61c-d0fbc4df68d1.png)

Additionally there are 2 fixes for build warnings and an added gitignore for VSCode related filess