### PR TITLE
fix: interrupts in the linux rt_clock.hpp

### DIFF
--- a/include/cadmium/modeling/dynamic_model.hpp
+++ b/include/cadmium/modeling/dynamic_model.hpp
@@ -163,7 +163,7 @@ namespace cadmium {
                 virtual void update() = 0;
 
             protected:
-                bool interrupted;
+                volatile bool interrupted;
                 std::vector <class AsyncEventSubject *> getSubject() {
                     return sub;
                 }

--- a/include/cadmium/real_time/linux/rt_clock.hpp
+++ b/include/cadmium/real_time/linux/rt_clock.hpp
@@ -39,7 +39,6 @@ static long MILI_TO_MICRO  = (1000);
 #ifndef MISSED_DEADLINE_TOLERANCE
   #define MISSED_DEADLINE_TOLERANCE -1
 #endif
-extern volatile bool interrupted;
 namespace cadmium {
     namespace embedded {
 
@@ -126,6 +125,7 @@ namespace cadmium {
             
             execution_timer.stop();
             if(interrupted) {
+			  interrupted = false;
               return delay_us - execution_timer.read_us();
             }
             return delay_us;
@@ -134,7 +134,9 @@ namespace cadmium {
 
        public:
 
-          rt_clock(std::vector < class cadmium::dynamic::modeling::AsyncEventSubject * > sub) : cadmium::dynamic::modeling::AsyncEventObserver(sub) {}
+          rt_clock(std::vector < class cadmium::dynamic::modeling::AsyncEventSubject * > sub) : cadmium::dynamic::modeling::AsyncEventObserver(sub) {
+			  interrupted = false;
+		  }
 
             /**
              * @brief wait_for delays simulation by given time


### PR DESCRIPTION
- Volatile bool interrupt was removed as it is not required
for the Linux rt_clock. The interrupt is set by the observer
pattern.
- The interrupt is now initialized in the rt_clock constructor.
It was never initialized as it was using a volatile global variable.
which is not required for the Linux rt_clock.
- The interrupt variable is now cleared after an interrupted is
registered and handled by the set_timeout function. It was never
cleared in the Linux rt_clock.
- Changed bool interrupt in dynamic_model.hpp AsyncEventObserver
to volatile bool interrupt. This is so that the wait loop in rt_clock
does not get optimized. This is useful if the memory is changed
from another location or a callback is used with the update function.
